### PR TITLE
[Backend] 無情的修改資料庫綱要

### DIFF
--- a/db/buyer.sql.go
+++ b/db/buyer.sql.go
@@ -169,35 +169,17 @@ func (q *Queries) AddProductToCart(ctx context.Context, arg AddProductToCartPara
 
 const checkout = `-- name: Checkout :exec
 WITH insert_order AS (
-INSERT INTO "order_history"("user_id", "shop_id", "image_id", "shipment", "total_price", "status")
+INSERT INTO "order_history"("user_id", "shop_id", "shipment", "total_price", "status")
     SELECT
         U."id",
         S."id",
-        T."image_id",
         $2,
         $3,
         'paid'
     FROM
         "user" AS U,
         "shop" AS S,
-        "cart" AS C,
-(
-            SELECT
-                "image_id"
-            FROM
-                "product"
-            WHERE
-                "id" =(
-                    SELECT
-                        "product_id"
-                    FROM
-                        "cart_product"
-                    WHERE
-                        "cart_id" = $4
-                    ORDER BY
-                        "price" DESC
-                    LIMIT 1 -- the most expensive product's image_id will be used as the thumbnail ↙️
-)) AS T
+        "cart" AS C
     WHERE
         U."username" = $1
         AND U."id" = C."user_id"
@@ -637,7 +619,7 @@ SELECT
     O."id",
     s."name" AS "shop_name",
     s."image_id" AS "shop_image_url",
-    O."image_id" AS "thumbnail_url",
+    OP."thumbnail_url",
     OP."product_name",
     O."shipment",
     O."total_price",
@@ -650,7 +632,8 @@ FROM
     LEFT JOIN (
         SELECT
             OD."order_id",
-            PA."name" AS "product_name"
+            PA."name" AS "product_name",
+            PA."image_id" AS "thumbnail_url"
         FROM
             "order_detail" AS OD
             INNER JOIN "product_archive" AS PA ON OD."product_id" = PA."id"

--- a/db/migrations/000001_db_setup.up.sql
+++ b/db/migrations/000001_db_setup.up.sql
@@ -1,4 +1,4 @@
-CREATE TYPE "order_status" AS ENUM (
+CREATE TYPE "order_status" AS ENUM(
     'paid',
     'shipped',
     'delivered',
@@ -6,41 +6,41 @@ CREATE TYPE "order_status" AS ENUM (
     'finished'
 );
 
-CREATE TYPE "coupon_type" AS ENUM (
+CREATE TYPE "coupon_type" AS ENUM(
     'percentage',
     'fixed',
     'shipping'
 );
 
-CREATE TYPE "coupon_scope" AS ENUM (
+CREATE TYPE "coupon_scope" AS ENUM(
     'global',
     'shop'
 );
 
-CREATE TYPE "role_type" AS ENUM (
+CREATE TYPE "role_type" AS ENUM(
     'admin',
     'customer'
 );
 
-CREATE TABLE "cart" (
+CREATE TABLE "cart"(
     "id" SERIAL PRIMARY KEY,
     "user_id" INT NOT NULL,
     "shop_id" INT NOT NULL,
     CONSTRAINT unique_shop_user UNIQUE ("shop_id", "user_id")
 );
 
-CREATE TABLE "cart_product" (
+CREATE TABLE "cart_product"(
     "cart_id" INT NOT NULL,
     "product_id" INT NOT NULL,
     "quantity" INT NOT NULL,
     CONSTRAINT unique_cart_product UNIQUE ("cart_id", "product_id")
 );
 
-CREATE TABLE "order_history" (
+CREATE TABLE "order_history"(
     "id" SERIAL PRIMARY KEY,
     "user_id" INT NOT NULL,
     "shop_id" INT NOT NULL,
-    "image_id" TEXT,
+    "image_id" TEXT NOT NULL,
     -- fot thumbnail
     "shipment" INT NOT NULL,
     "total_price" INT NOT NULL,
@@ -48,7 +48,7 @@ CREATE TABLE "order_history" (
     "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE "order_detail" (
+CREATE TABLE "order_detail"(
     "order_id" INT NOT NULL,
     "product_id" INT NOT NULL,
     "product_version" INT NOT NULL,
@@ -56,13 +56,13 @@ CREATE TABLE "order_detail" (
     PRIMARY KEY ("order_id", "product_id", "product_version")
 );
 
-CREATE TABLE "cart_coupon" (
+CREATE TABLE "cart_coupon"(
     "cart_id" INT NOT NULL,
     "coupon_id" INT NOT NULL,
     CONSTRAINT unique_cart_coupon UNIQUE ("cart_id", "coupon_id")
 );
 
-CREATE TABLE "product" (
+CREATE TABLE "product"(
     "id" SERIAL PRIMARY KEY,
     "version" INT NOT NULL,
     "shop_id" INT NOT NULL,
@@ -78,17 +78,17 @@ CREATE TABLE "product" (
     "enabled" BOOLEAN NOT NULL DEFAULT TRUE
 );
 
-CREATE TABLE "product_archive" (
+CREATE TABLE "product_archive"(
     "id" INT NOT NULL,
     "version" INT NOT NULL DEFAULT 1,
     "name" TEXT NOT NULL,
     "description" TEXT NOT NULL,
     "price" DECIMAL(10, 2) NOT NULL,
-    "image_id" TEXT,
+    "image_id" TEXT NOT NULL,
     PRIMARY KEY ("id", "version")
 );
 
-CREATE TABLE "coupon" (
+CREATE TABLE "coupon"(
     "id" SERIAL PRIMARY KEY,
     "type" coupon_type NOT NULL,
     "scope" coupon_scope NOT NULL,
@@ -100,98 +100,98 @@ CREATE TABLE "coupon" (
     "expire_date" TIMESTAMPTZ NOT NULL CHECK ("expire_date" > "start_date")
 );
 
-CREATE TABLE "user" (
+CREATE TABLE "user"(
     "id" SERIAL PRIMARY KEY,
     "username" TEXT NOT NULL UNIQUE,
     "password" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "email" TEXT NOT NULL UNIQUE,
     "address" TEXT NOT NULL,
-    "image_id" TEXT,
+    "image_id" TEXT NOT NULL,
     "role" role_type NOT NULL,
     "credit_card" JSONB NOT NULL,
     "refresh_token" TEXT NULL,
     "enabled" BOOLEAN NOT NULL DEFAULT TRUE -- if user deleted, set enabled to false
 );
 
-CREATE TABLE "shop" (
+CREATE TABLE "shop"(
     "id" SERIAL PRIMARY KEY,
     "seller_name" TEXT NOT NULL,
-    "image_id" TEXT,
+    "image_id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "description" TEXT NOT NULL,
     "enabled" BOOLEAN NOT NULL
 );
 
-CREATE TABLE "tag" (
+CREATE TABLE "tag"(
     "id" SERIAL PRIMARY KEY,
     "shop_id" INT NOT NULL,
     "name" TEXT NOT NULL,
     CONSTRAINT unique_name_shop UNIQUE ("shop_id", "name")
 );
 
-CREATE TABLE "product_tag" (
+CREATE TABLE "product_tag"(
     "tag_id" INT NOT NULL,
     "product_id" INT NOT NULL,
     CONSTRAINT unique_tag_product UNIQUE ("tag_id", "product_id")
 );
 
-CREATE TABLE "coupon_tag" (
+CREATE TABLE "coupon_tag"(
     "coupon_id" INT NOT NULL,
     "tag_id" INT NOT NULL,
     CONSTRAINT unique_tag_coupon UNIQUE ("tag_id", "coupon_id")
 );
 
 ALTER TABLE "shop"
-    ADD FOREIGN KEY ("seller_name") REFERENCES "user" ("username");
+    ADD FOREIGN KEY ("seller_name") REFERENCES "user"("username");
 
 ALTER TABLE "product"
-    ADD FOREIGN KEY ("shop_id") REFERENCES "shop" ("id");
+    ADD FOREIGN KEY ("shop_id") REFERENCES "shop"("id");
 
 ALTER TABLE "coupon"
-    ADD FOREIGN KEY ("shop_id") REFERENCES "shop" ("id");
+    ADD FOREIGN KEY ("shop_id") REFERENCES "shop"("id");
 
 ALTER TABLE "tag"
-    ADD FOREIGN KEY ("shop_id") REFERENCES "shop" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("shop_id") REFERENCES "shop"("id") ON DELETE CASCADE;
 
 ALTER TABLE "product_tag"
-    ADD FOREIGN KEY ("product_id") REFERENCES "product" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("product_id") REFERENCES "product"("id") ON DELETE CASCADE;
 
 ALTER TABLE "product_tag"
-    ADD FOREIGN KEY ("tag_id") REFERENCES "tag" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("tag_id") REFERENCES "tag"("id") ON DELETE CASCADE;
 
 ALTER TABLE "coupon_tag"
-    ADD FOREIGN KEY ("coupon_id") REFERENCES "coupon" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("coupon_id") REFERENCES "coupon"("id") ON DELETE CASCADE;
 
 ALTER TABLE "coupon_tag"
-    ADD FOREIGN KEY ("tag_id") REFERENCES "tag" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("tag_id") REFERENCES "tag"("id") ON DELETE CASCADE;
 
 ALTER TABLE "cart"
-    ADD FOREIGN KEY ("user_id") REFERENCES "user" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE;
 
 ALTER TABLE "cart"
-    ADD FOREIGN KEY ("shop_id") REFERENCES "shop" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("shop_id") REFERENCES "shop"("id") ON DELETE CASCADE;
 
 ALTER TABLE "cart_product"
-    ADD FOREIGN KEY ("cart_id") REFERENCES "cart" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("cart_id") REFERENCES "cart"("id") ON DELETE CASCADE;
 
 ALTER TABLE "cart_product"
-    ADD FOREIGN KEY ("product_id") REFERENCES "product" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("product_id") REFERENCES "product"("id") ON DELETE CASCADE;
 
 ALTER TABLE "cart_coupon"
-    ADD FOREIGN KEY ("cart_id") REFERENCES "cart" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("cart_id") REFERENCES "cart"("id") ON DELETE CASCADE;
 
 ALTER TABLE "cart_coupon"
-    ADD FOREIGN KEY ("coupon_id") REFERENCES "coupon" ("id") ON DELETE CASCADE;
+    ADD FOREIGN KEY ("coupon_id") REFERENCES "coupon"("id") ON DELETE CASCADE;
 
 ALTER TABLE "order_detail"
-    ADD FOREIGN KEY ("order_id") REFERENCES "order_history" ("id");
+    ADD FOREIGN KEY ("order_id") REFERENCES "order_history"("id");
 
 ALTER TABLE "order_detail"
-    ADD FOREIGN KEY ("product_id", "product_version") REFERENCES "product_archive" ("id", "version");
+    ADD FOREIGN KEY ("product_id", "product_version") REFERENCES "product_archive"("id", "version");
 
 ALTER TABLE "order_history"
-    ADD FOREIGN KEY ("user_id") REFERENCES "user" ("id");
+    ADD FOREIGN KEY ("user_id") REFERENCES "user"("id");
 
 ALTER TABLE "order_history"
-    ADD FOREIGN KEY ("shop_id") REFERENCES "shop" ("id");
+    ADD FOREIGN KEY ("shop_id") REFERENCES "shop"("id");

--- a/db/migrations/000001_db_setup.up.sql
+++ b/db/migrations/000001_db_setup.up.sql
@@ -40,8 +40,6 @@ CREATE TABLE "order_history"(
     "id" SERIAL PRIMARY KEY,
     "user_id" INT NOT NULL,
     "shop_id" INT NOT NULL,
-    "image_id" TEXT NOT NULL,
-    -- fot thumbnail
     "shipment" INT NOT NULL,
     "total_price" INT NOT NULL,
     "status" order_status NOT NULL,

--- a/db/models.go
+++ b/db/models.go
@@ -229,7 +229,6 @@ type OrderHistory struct {
 	ID         int32              `json:"id" param:"id"`
 	UserID     int32              `json:"user_id"`
 	ShopID     int32              `json:"shop_id"`
-	ImageID    string             `json:"image_id"`
 	Shipment   int32              `json:"shipment"`
 	TotalPrice int32              `json:"total_price"`
 	Status     OrderStatus        `json:"status"`

--- a/db/queries/buyer.sql
+++ b/db/queries/buyer.sql
@@ -3,7 +3,7 @@ SELECT
     O."id",
     s."name" AS "shop_name",
     s."image_id" AS "shop_image_url",
-    O."image_id" AS "thumbnail_url",
+    OP."thumbnail_url",
     OP."product_name",
     O."shipment",
     O."total_price",
@@ -16,7 +16,8 @@ FROM
     LEFT JOIN (
         SELECT
             OD."order_id",
-            PA."name" AS "product_name"
+            PA."name" AS "product_name",
+            PA."image_id" AS "thumbnail_url"
         FROM
             "order_detail" AS OD
             INNER JOIN "product_archive" AS PA ON OD."product_id" = PA."id"
@@ -473,35 +474,17 @@ WHERE
 
 -- name: Checkout :exec
 WITH insert_order AS (
-INSERT INTO "order_history"("user_id", "shop_id", "image_id", "shipment", "total_price", "status")
+INSERT INTO "order_history"("user_id", "shop_id", "shipment", "total_price", "status")
     SELECT
         U."id",
         S."id",
-        T."image_id",
         $2,
         $3,
         'paid'
     FROM
         "user" AS U,
         "shop" AS S,
-        "cart" AS C,
-(
-            SELECT
-                "image_id"
-            FROM
-                "product"
-            WHERE
-                "id" =(
-                    SELECT
-                        "product_id"
-                    FROM
-                        "cart_product"
-                    WHERE
-                        "cart_id" = @cart_id
-                    ORDER BY
-                        "price" DESC
-                    LIMIT 1 -- the most expensive product's image_id will be used as the thumbnail ↙️
-)) AS T
+        "cart" AS C
     WHERE
         U."username" = $1
         AND U."id" = C."user_id"

--- a/db/queries/buyer.sql
+++ b/db/queries/buyer.sql
@@ -17,11 +17,15 @@ FROM
         SELECT
             OD."order_id",
             PA."name" AS "product_name",
-            PA."image_id" AS "thumbnail_url"
+            PA."image_id" AS "thumbnail_url",
+            ROW_NUMBER() OVER (PARTITION BY OD."order_id" ORDER BY PA."price" DESC) AS rn
         FROM
             "order_detail" AS OD
             INNER JOIN "product_archive" AS PA ON OD."product_id" = PA."id"
-                AND OD."product_version" = PA."version") AS OP ON O."id" = OP."order_id"
+                AND OD."product_version" = PA."version"
+            ORDER BY
+                PA."price" DESC) AS OP ON O."id" = OP."order_id"
+    AND OP.rn = 1
 WHERE
     U."username" = $1
 ORDER BY
@@ -559,13 +563,13 @@ insert_archive AS (
 INSERT INTO "product_archive"("id", "version", "name", "description", "price", "image_id")
     SELECT
         P."id",
-        P."version" + COALESCE(0,(
-                SELECT
-                    1
-                FROM Check_version
-                WHERE
-                    "product_existed" = TRUE
-                    AND "version_existed" = FALSE)),
+        P."version" + COALESCE((
+            SELECT
+                1
+            FROM Check_version
+            WHERE
+                "product_existed" = TRUE
+                AND "version_existed" = FALSE), 0),
         P."name",
         P."description",
         P."price",

--- a/db/queries/test.sql
+++ b/db/queries/test.sql
@@ -1,146 +1,80 @@
 -- name: TestInsertUser :one
-INSERT INTO "user" (
-        "id",
-        "username",
-        "password",
-        "name",
-        "email",
-        "address",
-        "image_id",
-        "role",
-        "credit_card",
-        "refresh_token",
-        "enabled"
-    )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING *;
+INSERT INTO "user"("id", "username", "password", "name", "email", "address", "image_id", "role", "credit_card", "refresh_token", "enabled")
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+RETURNING
+    *;
 
 -- name: TestInsertShop :one
-INSERT INTO "shop" (
-        "id",
-        "seller_name",
-        "name",
-        "image_id",
-        "description",
-        "enabled"
-    )
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING *;
+INSERT INTO "shop"("id", "seller_name", "name", "image_id", "description", "enabled")
+    VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING
+    *;
 
 -- name: TestInsertCoupon :one
-INSERT INTO "coupon" (
-        "id",
-        "type",
-        "scope",
-        "shop_id",
-        "name",
-        "description",
-        "discount",
-        "start_date",
-        "expire_date"
-    )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-RETURNING *;
+INSERT INTO "coupon"("id", "type", "scope", "shop_id", "name", "description", "discount", "start_date", "expire_date")
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING
+    *;
 
 -- name: TestInsertProduct :one
-INSERT INTO "product" (
-        "id",
-        "version",
-        "shop_id",
-        "name",
-        "description",
-        "price",
-        "image_id",
-        "expire_date",
-        "edit_date",
-        "stock",
-        "sales",
-        "enabled"
-    )
-VALUES (
-        $1,
-        $2,
-        $3,
-        $4,
-        $5,
-        $6,
-        $7,
-        NOW(),
-        $8,
-        $9,
-        $10,
-        $11
-    )
-RETURNING *;
+INSERT INTO "product"("id", "version", "shop_id", "name", "description", "price", "image_id", "expire_date", "edit_date", "stock", "sales", "enabled")
+    VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8, $9, $10, $11)
+RETURNING
+    *;
 
 -- name: TestInsertProductArchive :one
-INSERT INTO "product_archive" (
-        "id",
-        "version",
-        "name",
-        "description",
-        "price",
-        "image_id"
-    )
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING *;
+INSERT INTO "product_archive"("id", "version", "name", "description", "price", "image_id")
+    VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING
+    *;
 
 -- name: TestInsertTag :one
-INSERT INTO "tag" ("id", "shop_id", "name")
-VALUES ($1, $2, $3)
-RETURNING *;
+INSERT INTO "tag"("id", "shop_id", "name")
+    VALUES ($1, $2, $3)
+RETURNING
+    *;
 
 -- name: TestInsertProductTag :one
-INSERT INTO "product_tag" ("tag_id", "product_id")
-VALUES ($1, $2)
-RETURNING *;
+INSERT INTO "product_tag"("tag_id", "product_id")
+    VALUES ($1, $2)
+RETURNING
+    *;
 
 -- name: TestInsertCouponTag :one
-INSERT INTO "coupon_tag" ("tag_id", "coupon_id")
-VALUES ($1, $2)
-RETURNING *;
+INSERT INTO "coupon_tag"("tag_id", "coupon_id")
+    VALUES ($1, $2)
+RETURNING
+    *;
 
 -- name: TestInsertCart :one
-INSERT INTO "cart" ("id", "user_id", "shop_id")
-VALUES ($1, $2, $3)
-RETURNING *;
+INSERT INTO "cart"("id", "user_id", "shop_id")
+    VALUES ($1, $2, $3)
+RETURNING
+    *;
 
 -- name: TestInsertCartProduct :one
-INSERT INTO "cart_product" (
-        "cart_id",
-        "product_id",
-        "quantity"
-    )
-VALUES ($1, $2, $3)
-RETURNING *;
+INSERT INTO "cart_product"("cart_id", "product_id", "quantity")
+    VALUES ($1, $2, $3)
+RETURNING
+    *;
 
 -- name: TestInsertCartCoupon :one
-INSERT INTO "cart_coupon" ("cart_id", "coupon_id")
-VALUES ($1, $2)
-RETURNING *;
+INSERT INTO "cart_coupon"("cart_id", "coupon_id")
+    VALUES ($1, $2)
+RETURNING
+    *;
 
 -- name: TestInsertOrderHistory :one
-INSERT INTO "order_history" (
-        "id",
-        "user_id",
-        "shop_id",
-        "image_id",
-        "shipment",
-        "total_price",
-        "status"
-    )
-VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING *;
+INSERT INTO "order_history"("id", "user_id", "shop_id", "shipment", "total_price", "status")
+    VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING
+    *;
 
 -- name: TestInsertOrderDetail :one
-INSERT INTO "order_detail" (
-        "order_id",
-        "product_id",
-        "product_version",
-        "quantity"
-    )
-VALUES ($1, $2, $3, $4)
-RETURNING *;
+INSERT INTO "order_detail"("order_id", "product_id", "product_version", "quantity")
+    VALUES ($1, $2, $3, $4)
+RETURNING
+    *;
 
 -- name: TestDeleteUserById :execrows
 DELETE FROM "user"

--- a/db/queries/user.sql
+++ b/db/queries/user.sql
@@ -1,121 +1,128 @@
 -- name: UserGetInfo :one
-SELECT "name",
+SELECT
+    "name",
     "email",
     "address",
-    "image_id" as "image_url"
-FROM "user" u
-WHERE u."username" = $1;
+    "image_id" AS "image_url"
+FROM
+    "user" u
+WHERE
+    u."username" = $1;
 
 -- name: UserUpdateInfo :one
-UPDATE "user"
-SET "name" = COALESCE($2, "name"),
+UPDATE
+    "user"
+SET
+    "name" = COALESCE($2, "name"),
     "email" = COALESCE($3, "email"),
     "address" = COALESCE($4, "address"),
-    "image_id" = CASE
-        WHEN sqlc.arg('image_id')::TEXT = '' THEN "image_id"
-        ELSE sqlc.arg('image_id')::TEXT
+    "image_id" = CASE WHEN sqlc.arg('image_id')::TEXT = '' THEN
+        "image_id"
+    ELSE
+        sqlc.arg('image_id')::TEXT
     END
-WHERE "username" = $1
-RETURNING "name",
+WHERE
+    "username" = $1
+RETURNING
+    "name",
     "email",
     "address",
-    "image_id" as "image_url";
+    "image_id" AS "image_url";
 
 -- name: UserGetPassword :one
-SELECT "password"
-FROM "user"
-WHERE "username" = $1;
+SELECT
+    "password"
+FROM
+    "user"
+WHERE
+    "username" = $1;
 
 -- name: UserUpdatePassword :one
-UPDATE "user"
-SET "password" = sqlc.arg(new_password)
-WHERE "username" = $1
-RETURNING "name",
+UPDATE
+    "user"
+SET
+    "password" = sqlc.arg(new_password)
+WHERE
+    "username" = $1
+RETURNING
+    "name",
     "email",
     "address",
-    "image_id" as "image_url";
+    "image_id" AS "image_url";
 
 -- name: UserGetCreditCard :one
-SELECT "credit_card"
-FROM "user"
-WHERE "username" = $1;
+SELECT
+    "credit_card"
+FROM
+    "user"
+WHERE
+    "username" = $1;
 
 -- name: UserUpdateCreditCard :one
-UPDATE "user"
-SET "credit_card" = $2
-WHERE "username" = $1
-RETURNING "credit_card";
+UPDATE
+    "user"
+SET
+    "credit_card" = $2
+WHERE
+    "username" = $1
+RETURNING
+    "credit_card";
 
 -- name: AddUser :exec
-INSERT INTO "user" (
-        "username",
-        "password",
-        "name",
-        "email",
-        "address",
-        "role",
-        "credit_card",
-        "enabled"
-    )
-VALUES (
-        $1,
-        $2,
-        $3,
-        $4,
-        $5,
-        'customer',
-        '{}',
-        TRUE
-    );
+INSERT INTO "user"("username", "password", "name", "email", "address", "role", "credit_card", "enabled", "image_id")
+    VALUES ($1, $2, $3, $4, $5, 'customer', '{}', TRUE, '');
 
 -- name: UserExists :one
-SELECT EXISTS (
-        SELECT 1
-        FROM "user"
-        WHERE "username" = $1
-            OR "email" = $2
-    );
+SELECT
+    EXISTS (
+        SELECT
+            1
+        FROM
+            "user"
+        WHERE
+            "username" = $1
+            OR "email" = $2);
 
 -- user can enter both username and email to verify
 -- but writing "usernameOrEmail" is too long
 -- name: FindUserInfoAndPassword :one
-SELECT "username",
+SELECT
+    "username",
     "role",
     "password"
-FROM "user"
-WHERE "username" = $1
+FROM
+    "user"
+WHERE
+    "username" = $1
     OR "email" = $1;
 
 -- name: SetRefreshToken :exec
-UPDATE "user"
-SET "refresh_token" = @refresh_token,
+UPDATE
+    "user"
+SET
+    "refresh_token" = @refresh_token,
     "refresh_token_expire_date" = @expire_date
-WHERE "username" = @username;
+WHERE
+    "username" = @username;
 
 -- name: FindUserByRefreshToken :one
-SELECT "username",
+SELECT
+    "username",
     "role"
-FROM "user"
-WHERE "refresh_token" = @refresh_token
+FROM
+    "user"
+WHERE
+    "refresh_token" = @refresh_token
     AND "refresh_token_expire_date" > NOW();
 
 -- name: DeleteRefreshToken :exec
-UPDATE "user"
-SET "refresh_token" = NULL
-WHERE "refresh_token" = @refresh_token;
+UPDATE
+    "user"
+SET
+    "refresh_token" = NULL
+WHERE
+    "refresh_token" = @refresh_token;
 
 -- name: AddShop :exec
-INSERT INTO "shop" (
-        "seller_name",
-        "image_id",
-        "name",
-        "description",
-        "enabled"
-    )
-VALUES(
-        @seller_name,
-        NULL,
-        @name,
-        '',
-        FALSE
-    );
+INSERT INTO "shop"("seller_name", "image_id", "name", "description", "enabled")
+    VALUES (@seller_name, '', @name, '', FALSE);

--- a/db/seller.sql.go
+++ b/db/seller.sql.go
@@ -12,13 +12,16 @@ import (
 )
 
 const haveTagName = `-- name: HaveTagName :one
-SELECT EXISTS (
-        SELECT 1
-        FROM "tag" t
-            LEFT JOIN "shop" s ON "shop_id" = s.id
-        WHERE s."seller_name" = $1
-            AND t."name" = $2
-    )
+SELECT
+    EXISTS (
+        SELECT
+            1
+        FROM
+            "tag" t
+        LEFT JOIN "shop" s ON "shop_id" = s.id
+    WHERE
+        s."seller_name" = $1
+        AND t."name" = $2)
 `
 
 type HaveTagNameParams struct {
@@ -34,28 +37,33 @@ func (q *Queries) HaveTagName(ctx context.Context, arg HaveTagNameParams) (bool,
 }
 
 const sellerBestSellProduct = `-- name: SellerBestSellProduct :many
-SELECT order_detail.product_id,
+SELECT
+    order_detail.product_id,
     product_archive.name,
     product_archive.price,
-    product_archive.image_id as "image_url",
+    product_archive.image_id AS "image_url",
     SUM(order_detail.quantity) AS total_quantity,
     SUM(order_detail.quantity * product_archive.price)::decimal(10, 2) AS total_sell,
     COUNT(order_history.id) AS order_count
-FROM "order_detail"
+FROM
+    "order_detail"
     LEFT JOIN product_archive ON order_detail.product_id = product_archive.id
-    AND order_detail.product_version = product_archive.version
+        AND order_detail.product_version = product_archive.version
     LEFT JOIN order_history ON order_history.id = order_detail.order_id
     LEFT JOIN shop ON order_history.shop_id = shop.id
-WHERE shop.seller_name = $1
+WHERE
+    shop.seller_name = $1
     AND order_history."created_at" > $3
     AND order_history."created_at" < $3 + INTERVAL '1 month'
-GROUP BY product_archive.id,
+GROUP BY
+    product_archive.id,
     product_archive.description,
     product_archive.name,
     product_archive.price,
     product_archive.image_id,
     order_detail.product_id
-ORDER BY total_quantity DESC
+ORDER BY
+    total_quantity DESC
 LIMIT $2
 `
 
@@ -104,14 +112,17 @@ func (q *Queries) SellerBestSellProduct(ctx context.Context, arg SellerBestSellP
 }
 
 const sellerCheckTags = `-- name: SellerCheckTags :one
-SELECT NOT EXISTS (
-        SELECT 1
-        FROM unnest($2::INT []) t
-            LEFT JOIN "tag" ON t = "tag"."id"
-            LEFT JOIN "shop" s ON "tag"."shop_id" = s."id"
-        WHERE "tag"."id" IS NULL
-            OR s."seller_name" != $1
-    )
+SELECT
+    NOT EXISTS (
+        SELECT
+            1
+        FROM
+            unnest($2::INT[]) t
+        LEFT JOIN "tag" ON t = "tag"."id"
+        LEFT JOIN "shop" s ON "tag"."shop_id" = s."id"
+    WHERE
+        "tag"."id" IS NULL
+        OR s."seller_name" != $1)
 `
 
 type SellerCheckTagsParams struct {
@@ -129,12 +140,14 @@ func (q *Queries) SellerCheckTags(ctx context.Context, arg SellerCheckTagsParams
 const sellerDeleteCoupon = `-- name: SellerDeleteCoupon :execrows
 DELETE FROM "coupon" c
 WHERE c."id" = $2
-    AND "shop_id" = (
-        SELECT s."id"
-        FROM "shop" s
-        WHERE s."seller_name" = $1
-            AND s."enabled" = true
-    )
+    AND "shop_id" =(
+        SELECT
+            s."id"
+        FROM
+            "shop" s
+        WHERE
+            s."seller_name" = $1
+            AND s."enabled" = TRUE)
 `
 
 type SellerDeleteCouponParams struct {
@@ -153,13 +166,15 @@ func (q *Queries) SellerDeleteCoupon(ctx context.Context, arg SellerDeleteCoupon
 const sellerDeleteCouponTag = `-- name: SellerDeleteCouponTag :execrows
 DELETE FROM "coupon_tag" tp
 WHERE EXISTS (
-        SELECT 1
-        FROM "coupon" c
+        SELECT
+            1
+        FROM
+            "coupon" c
             JOIN "shop" s ON s."id" = c."shop_id"
-        WHERE s."seller_name" = $1
-            AND s."enabled" = true
-            AND c."id" = $3
-    )
+        WHERE
+            s."seller_name" = $1
+            AND s."enabled" = TRUE
+            AND c."id" = $3)
     AND "coupon_id" = $3
     AND "tag_id" = $2
 `
@@ -180,12 +195,14 @@ func (q *Queries) SellerDeleteCouponTag(ctx context.Context, arg SellerDeleteCou
 
 const sellerDeleteProduct = `-- name: SellerDeleteProduct :execrows
 DELETE FROM "product" p
-WHERE "shop_id" = (
-        SELECT s."id"
-        FROM "shop" s
-        WHERE s."seller_name" = $1
-            AND s."enabled" = true
-    )
+WHERE "shop_id" =(
+        SELECT
+            s."id"
+        FROM
+            "shop" s
+        WHERE
+            s."seller_name" = $1
+            AND s."enabled" = TRUE)
     AND p."id" = $2
 `
 
@@ -205,13 +222,15 @@ func (q *Queries) SellerDeleteProduct(ctx context.Context, arg SellerDeleteProdu
 const sellerDeleteProductTag = `-- name: SellerDeleteProductTag :execrows
 DELETE FROM "product_tag" tp
 WHERE EXISTS (
-        SELECT 1
-        FROM "product" p
+        SELECT
+            1
+        FROM
+            "product" p
             JOIN "shop" s ON s."id" = p."shop_id"
-        WHERE s."seller_name" = $1
+        WHERE
+            s."seller_name" = $1
             AND p."id" = $3
-            AND s."enabled" = true
-    )
+            AND s."enabled" = TRUE)
     AND "product_id" = $3
     AND "tag_id" = $2
 `
@@ -231,7 +250,8 @@ func (q *Queries) SellerDeleteProductTag(ctx context.Context, arg SellerDeletePr
 }
 
 const sellerGetCoupon = `-- name: SellerGetCoupon :many
-SELECT c."id",
+SELECT
+    c."id",
     c."type",
     c."scope",
     c."name",
@@ -239,10 +259,13 @@ SELECT c."id",
     c."discount",
     c."start_date",
     c."expire_date"
-FROM "coupon" c
+FROM
+    "coupon" c
     JOIN "shop" s ON c."shop_id" = s.id
-WHERE s.seller_name = $1
-ORDER BY "start_date" DESC
+WHERE
+    s.seller_name = $1
+ORDER BY
+    "start_date" DESC
 LIMIT $2 OFFSET $3
 `
 
@@ -293,16 +316,19 @@ func (q *Queries) SellerGetCoupon(ctx context.Context, arg SellerGetCouponParams
 }
 
 const sellerGetCouponDetail = `-- name: SellerGetCouponDetail :one
-SELECT c."type",
+SELECT
+    c."type",
     c."scope",
     c."name",
     c."discount",
     c."description",
     c."start_date",
     c."expire_date"
-FROM "coupon" c
+FROM
+    "coupon" c
     JOIN "shop" s ON c."shop_id" = s.id
-WHERE s."seller_name" = $1
+WHERE
+    s."seller_name" = $1
     AND c."id" = $2
 `
 
@@ -337,13 +363,16 @@ func (q *Queries) SellerGetCouponDetail(ctx context.Context, arg SellerGetCoupon
 }
 
 const sellerGetCouponTag = `-- name: SellerGetCouponTag :many
-SELECT ct."tag_id",
+SELECT
+    ct."tag_id",
     t."name"
-FROM "coupon_tag" ct
+FROM
+    "coupon_tag" ct
     JOIN "coupon" c ON c."id" = ct."coupon_id"
     JOIN "shop" s ON s."id" = c."shop_id"
     JOIN "tag" t ON t."id" = ct."tag_id"
-WHERE s."seller_name" = $1
+WHERE
+    s."seller_name" = $1
     AND "coupon_id" = $2
 `
 
@@ -378,12 +407,15 @@ func (q *Queries) SellerGetCouponTag(ctx context.Context, arg SellerGetCouponTag
 }
 
 const sellerGetInfo = `-- name: SellerGetInfo :one
-SELECT "name",
-    "image_id" as "image_url",
+SELECT
+    "name",
+    "image_id" AS "image_url",
     "description",
     "enabled"
-FROM "shop"
-WHERE "seller_name" = $1
+FROM
+    "shop"
+WHERE
+    "seller_name" = $1
 `
 
 type SellerGetInfoRow struct {
@@ -406,19 +438,24 @@ func (q *Queries) SellerGetInfo(ctx context.Context, sellerName string) (SellerG
 }
 
 const sellerGetOrder = `-- name: SellerGetOrder :many
-SELECT "id",
-    oh."image_id" as "image_url",
+SELECT
+    "id",
     oh."shipment",
     oh."total_price",
     oh."status",
     oh."created_at"
-FROM "order_history" as oh
-WHERE "shop_id" = (
-        SELECT s."id"
-        FROM "shop" s
-        WHERE s."seller_name" = $1
-    )
-ORDER BY "created_at" DESC
+FROM
+    "order_history" AS oh
+WHERE
+    "shop_id" =(
+        SELECT
+            s."id"
+        FROM
+            "shop" s
+        WHERE
+            s."seller_name" = $1)
+ORDER BY
+    "created_at" DESC
 LIMIT $2 OFFSET $3
 `
 
@@ -430,7 +467,6 @@ type SellerGetOrderParams struct {
 
 type SellerGetOrderRow struct {
 	ID         int32              `json:"id" param:"id"`
-	ImageUrl   string             `json:"image_url"`
 	Shipment   int32              `json:"shipment"`
 	TotalPrice int32              `json:"total_price"`
 	Status     OrderStatus        `json:"status"`
@@ -448,7 +484,6 @@ func (q *Queries) SellerGetOrder(ctx context.Context, arg SellerGetOrderParams) 
 		var i SellerGetOrderRow
 		if err := rows.Scan(
 			&i.ID,
-			&i.ImageUrl,
 			&i.Shipment,
 			&i.TotalPrice,
 			&i.Status,
@@ -465,20 +500,24 @@ func (q *Queries) SellerGetOrder(ctx context.Context, arg SellerGetOrderParams) 
 }
 
 const sellerGetOrderDetail = `-- name: SellerGetOrderDetail :many
-SELECT product_archive."id",
+SELECT
+    product_archive."id",
     product_archive."name",
     product_archive."description",
     product_archive."price",
-    product_archive."image_id" as "image_url",
+    product_archive."image_id" AS "image_url",
     order_detail.quantity
-FROM "order_detail"
+FROM
+    "order_detail"
     LEFT JOIN product_archive ON order_detail.product_id = product_archive.id
-    AND order_detail.product_version = product_archive.version
+        AND order_detail.product_version = product_archive.version
     LEFT JOIN order_history ON order_history.id = order_detail.order_id
     LEFT JOIN shop ON order_history.shop_id = shop.id
-WHERE shop.seller_name = $1
+WHERE
+    shop.seller_name = $1
     AND order_detail.order_id = $2
-ORDER BY quantity * price DESC
+ORDER BY
+    quantity * price DESC
 `
 
 type SellerGetOrderDetailParams struct {
@@ -523,19 +562,21 @@ func (q *Queries) SellerGetOrderDetail(ctx context.Context, arg SellerGetOrderDe
 }
 
 const sellerGetOrderHistory = `-- name: SellerGetOrderHistory :one
-SELECT "order_history"."id",
-    "order_history"."image_id" as "thumbnail_url",
+SELECT
+    "order_history"."id",
     "order_history"."shipment",
     "order_history"."total_price",
     "order_history"."status",
     "order_history"."created_at",
-    "user"."id" as "user_id",
-    "user"."name" as "user_name",
-    "user"."image_id" as "user_image_url"
-FROM "order_history"
+    "user"."id" AS "user_id",
+    "user"."name" AS "user_name",
+    "user"."image_id" AS "user_image_url"
+FROM
+    "order_history"
     JOIN shop ON "order_history".shop_id = shop.id
     JOIN "user" ON "order_history".user_id = "user"."id"
-WHERE shop.seller_name = $1
+WHERE
+    shop.seller_name = $1
     AND "order_history".id = $2
 `
 
@@ -546,7 +587,6 @@ type SellerGetOrderHistoryParams struct {
 
 type SellerGetOrderHistoryRow struct {
 	ID           int32              `json:"id" param:"id"`
-	ThumbnailUrl string             `json:"thumbnail_url"`
 	Shipment     int32              `json:"shipment"`
 	TotalPrice   int32              `json:"total_price"`
 	Status       OrderStatus        `json:"status"`
@@ -561,7 +601,6 @@ func (q *Queries) SellerGetOrderHistory(ctx context.Context, arg SellerGetOrderH
 	var i SellerGetOrderHistoryRow
 	err := row.Scan(
 		&i.ID,
-		&i.ThumbnailUrl,
 		&i.Shipment,
 		&i.TotalPrice,
 		&i.Status,
@@ -574,15 +613,18 @@ func (q *Queries) SellerGetOrderHistory(ctx context.Context, arg SellerGetOrderH
 }
 
 const sellerGetProductDetail = `-- name: SellerGetProductDetail :one
-SELECT p."name",
-    p."image_id" as "image_url",
+SELECT
+    p."name",
+    p."image_id" AS "image_url",
     p."price",
     p."sales",
     p."stock",
     p."enabled"
-FROM "product" p
+FROM
+    "product" p
     JOIN "shop" s ON p."shop_id" = s.id
-WHERE s.seller_name = $1
+WHERE
+    s.seller_name = $1
     AND p."id" = $2
 `
 
@@ -615,15 +657,18 @@ func (q *Queries) SellerGetProductDetail(ctx context.Context, arg SellerGetProdu
 }
 
 const sellerGetProductTag = `-- name: SellerGetProductTag :many
-SELECT pt."tag_id",
+SELECT
+    pt."tag_id",
     t."name"
-FROM "product_tag" pt
+FROM
+    "product_tag" pt
     JOIN "product" p ON p."id" = pt."product_id"
     JOIN "shop" s ON s."id" = p."shop_id"
     JOIN "tag" t ON t."id" = pt."tag_id"
-WHERE s."seller_name" = $1
+WHERE
+    s."seller_name" = $1
     AND "product_id" = $2
-    AND s."enabled" = true
+    AND s."enabled" = TRUE
 `
 
 type SellerGetProductTagParams struct {
@@ -657,32 +702,22 @@ func (q *Queries) SellerGetProductTag(ctx context.Context, arg SellerGetProductT
 }
 
 const sellerInsertCoupon = `-- name: SellerInsertCoupon :one
-INSERT INTO "coupon" (
-        "type",
-        "scope",
-        "shop_id",
-        "name",
-        "description",
-        "discount",
-        "start_date",
-        "expire_date"
-    )
-VALUES (
-        $2,
-        'shop',
-        (
-            SELECT s."id"
-            FROM "shop" s
-            WHERE s."seller_name" = $1
-                AND s."enabled" = true
-        ),
-        $3,
-        $4,
-        $5,
-        $6,
-        $7
-    )
-RETURNING "id",
+INSERT INTO "coupon"("type", "scope", "shop_id", "name", "description", "discount", "start_date", "expire_date")
+    VALUES ($2, 'shop',(
+            SELECT
+                s."id"
+            FROM
+                "shop" s
+            WHERE
+                s."seller_name" = $1
+                AND s."enabled" = TRUE),
+            $3,
+            $4,
+            $5,
+            $6,
+            $7)
+RETURNING
+    "id",
     "type",
     "scope",
     "name",
@@ -738,26 +773,33 @@ func (q *Queries) SellerInsertCoupon(ctx context.Context, arg SellerInsertCoupon
 }
 
 const sellerInsertCouponTag = `-- name: SellerInsertCouponTag :one
-INSERT INTO "coupon_tag" ("tag_id", "coupon_id")
-SELECT $2,
+INSERT INTO "coupon_tag"("tag_id", "coupon_id")
+SELECT
+    $2,
     $3
-WHERE EXISTS (
-        SELECT 1
-        FROM "tag" t
+WHERE
+    EXISTS (
+        SELECT
+            1
+        FROM
+            "tag" t
             JOIN "shop" s ON s."id" = t."shop_id"
-        WHERE s."seller_name" = $1
-            AND s."enabled" = true
-            AND t."id" = $2
-    )
+        WHERE
+            s."seller_name" = $1
+            AND s."enabled" = TRUE
+            AND t."id" = $2)
     AND EXISTS (
-        SELECT 1
-        FROM "coupon" c
+        SELECT
+            1
+        FROM
+            "coupon" c
             JOIN "shop" s ON s."id" = c."shop_id"
-        WHERE s."seller_name" = $1
-            AND s."enabled" = true
-            AND c."id" = $3
-    )
-RETURNING coupon_id, tag_id
+        WHERE
+            s."seller_name" = $1
+            AND s."enabled" = TRUE
+            AND c."id" = $3)
+RETURNING
+    coupon_id, tag_id
 `
 
 type SellerInsertCouponTagParams struct {
@@ -774,8 +816,8 @@ func (q *Queries) SellerInsertCouponTag(ctx context.Context, arg SellerInsertCou
 }
 
 const sellerInsertCouponTags = `-- name: SellerInsertCouponTags :exec
-INSERT INTO "coupon_tag" ("coupon_id", "tag_id")
-VALUES ($1, unnest($2::INT []))
+INSERT INTO "coupon_tag"("coupon_id", "tag_id")
+    VALUES ($1, unnest($2::INT[]))
 `
 
 type SellerInsertCouponTagsParams struct {
@@ -789,26 +831,14 @@ func (q *Queries) SellerInsertCouponTags(ctx context.Context, arg SellerInsertCo
 }
 
 const sellerInsertProduct = `-- name: SellerInsertProduct :one
-INSERT INTO "product"(
-        "version",
-        "shop_id",
-        "name",
-        "description",
-        "price",
-        "image_id",
-        "expire_date",
-        "edit_date",
-        "stock",
-        "enabled"
-    )
-VALUES (
-        1,
-        (
-            SELECT s."id"
+INSERT INTO "product"("version", "shop_id", "name", "description", "price", "image_id", "expire_date", "edit_date", "stock", "enabled")
+    VALUES (1,(
+            SELECT
+                s."id"
             FROM "shop" s
-            WHERE s."seller_name" = $1
-                AND s."enabled" = true
-        ),
+            WHERE
+                s."seller_name" = $1
+                AND s."enabled" = TRUE),
         $2,
         $3,
         $4,
@@ -816,13 +846,13 @@ VALUES (
         $6,
         NOW(),
         $7,
-        $8
-    )
-RETURNING "id",
+        $8)
+RETURNING
+    "id",
     "name",
     "description",
     "price",
-    "image_id" as "image_url",
+    "image_id" AS "image_url",
     "expire_date",
     "edit_date",
     "stock",
@@ -882,25 +912,32 @@ func (q *Queries) SellerInsertProduct(ctx context.Context, arg SellerInsertProdu
 }
 
 const sellerInsertProductTag = `-- name: SellerInsertProductTag :one
-INSERT INTO "product_tag" ("tag_id", "product_id")
-SELECT $2,
+INSERT INTO "product_tag"("tag_id", "product_id")
+SELECT
+    $2,
     $3
-WHERE EXISTS (
-        SELECT 1
-        FROM "tag" t
+WHERE
+    EXISTS (
+        SELECT
+            1
+        FROM
+            "tag" t
             JOIN "shop" s ON s."id" = t."shop_id"
-        WHERE s."seller_name" = $1
+        WHERE
+            s."seller_name" = $1
             AND t."id" = $2
-            AND s."enabled" = true
-    )
+            AND s."enabled" = TRUE)
     AND EXISTS (
-        SELECT 1
-        FROM "product" p
+        SELECT
+            1
+        FROM
+            "product" p
             JOIN "shop" s ON s."id" = p."shop_id"
-        WHERE s."seller_name" = $1
-            AND p."id" = $3
-    )
-RETURNING tag_id, product_id
+        WHERE
+            s."seller_name" = $1
+            AND p."id" = $3)
+RETURNING
+    tag_id, product_id
 `
 
 type SellerInsertProductTagParams struct {
@@ -917,8 +954,8 @@ func (q *Queries) SellerInsertProductTag(ctx context.Context, arg SellerInsertPr
 }
 
 const sellerInsertProductTags = `-- name: SellerInsertProductTags :exec
-INSERT INTO "product_tag" ("product_id", "tag_id")
-VALUES ($1, unnest($2::INT []))
+INSERT INTO "product_tag"("product_id", "tag_id")
+    VALUES ($1, unnest($2::INT[]))
 `
 
 type SellerInsertProductTagsParams struct {
@@ -932,17 +969,18 @@ func (q *Queries) SellerInsertProductTags(ctx context.Context, arg SellerInsertP
 }
 
 const sellerInsertTag = `-- name: SellerInsertTag :one
-INSERT INTO "tag" ("shop_id", "name")
-VALUES (
-        (
-            SELECT s."id"
-            FROM "shop" s
-            WHERE s."seller_name" = $1
-                AND s."enabled" = true
-        ),
-        $2
-    )
-RETURNING "id",
+INSERT INTO "tag"("shop_id", "name")
+    VALUES ((
+            SELECT
+                s."id"
+            FROM
+                "shop" s
+            WHERE
+                s."seller_name" = $1
+                AND s."enabled" = TRUE),
+            $2)
+RETURNING
+    "id",
     "name"
 `
 
@@ -964,17 +1002,21 @@ func (q *Queries) SellerInsertTag(ctx context.Context, arg SellerInsertTagParams
 }
 
 const sellerProductList = `-- name: SellerProductList :many
-SELECT p."id",
+SELECT
+    p."id",
     p."name",
-    p."image_id" as "image_url",
+    p."image_id" AS "image_url",
     p."price",
     p."sales",
     p."stock",
     p."enabled"
-FROM "product" p
+FROM
+    "product" p
     JOIN "shop" s ON p."shop_id" = s.id
-WHERE s.seller_name = $1
-ORDER BY "sales" DESC
+WHERE
+    s.seller_name = $1
+ORDER BY
+    "sales" DESC
 LIMIT $2 OFFSET $3
 `
 
@@ -1023,11 +1065,14 @@ func (q *Queries) SellerProductList(ctx context.Context, arg SellerProductListPa
 }
 
 const sellerReport = `-- name: SellerReport :one
-SELECT SUM(order_history.total_price)::decimal(10, 2) AS total_income,
+SELECT
+    SUM(order_history.total_price)::decimal(10, 2) AS total_income,
     COUNT(order_history.id) AS order_count
-FROM order_history
+FROM
+    order_history
     LEFT JOIN shop ON order_history.shop_id = shop.id
-WHERE shop.seller_name = $1
+WHERE
+    shop.seller_name = $1
     AND order_history."created_at" > $2
     AND order_history."created_at" < $2 + INTERVAL '1 month'
 `
@@ -1050,13 +1095,17 @@ func (q *Queries) SellerReport(ctx context.Context, arg SellerReportParams) (Sel
 }
 
 const sellerSearchTag = `-- name: SellerSearchTag :many
-SELECT t."id",
+SELECT
+    t."id",
     t."name"
-FROM "tag" t
+FROM
+    "tag" t
     LEFT JOIN "shop" s ON "shop_id" = s.id
-WHERE s."seller_name" = $1
+WHERE
+    s."seller_name" = $1
     AND t."name" ~* $2
-ORDER BY LENGTH(t."name") ASC
+ORDER BY
+    LENGTH(t."name") ASC
 LIMIT $3
 `
 
@@ -1092,21 +1141,27 @@ func (q *Queries) SellerSearchTag(ctx context.Context, arg SellerSearchTagParams
 }
 
 const sellerUpdateCouponInfo = `-- name: SellerUpdateCouponInfo :one
-UPDATE "coupon" c
-SET "type" = COALESCE($3, "type"),
+UPDATE
+    "coupon" c
+SET
+    "type" = COALESCE($3, "type"),
     "name" = COALESCE($4, "name"),
     "description" = COALESCE($5, "description"),
     "discount" = COALESCE($6, "discount"),
     "start_date" = COALESCE($7, "start_date"),
     "expire_date" = COALESCE($8, "expire_date")
-WHERE c."id" = $2
-    AND "shop_id" = (
-        SELECT s."id"
-        FROM "shop" s
-        WHERE s."seller_name" = $1
-            AND s."enabled" = true
-    )
-RETURNING c."id",
+WHERE
+    c."id" = $2
+    AND "shop_id" =(
+        SELECT
+            s."id"
+        FROM
+            "shop" s
+        WHERE
+            s."seller_name" = $1
+            AND s."enabled" = TRUE)
+RETURNING
+    c."id",
     c."type",
     c."scope",
     c."name",
@@ -1164,17 +1219,22 @@ func (q *Queries) SellerUpdateCouponInfo(ctx context.Context, arg SellerUpdateCo
 }
 
 const sellerUpdateInfo = `-- name: SellerUpdateInfo :one
-UPDATE "shop"
-SET "image_id" = CASE
-        WHEN $5::TEXT = '' THEN "image_id"
-        ELSE $5::TEXT
+UPDATE
+    "shop"
+SET
+    "image_id" = CASE WHEN $5::TEXT = '' THEN
+        "image_id"
+    ELSE
+        $5::TEXT
     END,
     "name" = COALESCE($2, "name"),
     "description" = COALESCE($3, "description"),
     "enabled" = COALESCE($4, "enabled")
-WHERE "seller_name" = $1
-RETURNING "name",
-    "image_id" as "image_url",
+WHERE
+    "seller_name" = $1
+RETURNING
+    "name",
+    "image_id" AS "image_url",
     "description",
     "enabled"
 `
@@ -1213,17 +1273,23 @@ func (q *Queries) SellerUpdateInfo(ctx context.Context, arg SellerUpdateInfoPara
 }
 
 const sellerUpdateOrderStatus = `-- name: SellerUpdateOrderStatus :one
-UPDATE "order_history" oh
-SET "status" = $3
-WHERE "shop_id" = (
-        SELECT s."id"
-        FROM "shop" s
-        WHERE s."seller_name" = $1
-            AND s."enabled" = true
-    )
+UPDATE
+    "order_history" oh
+SET
+    "status" = $3
+WHERE
+    "shop_id" =(
+        SELECT
+            s."id"
+        FROM
+            "shop" s
+        WHERE
+            s."seller_name" = $1
+            AND s."enabled" = TRUE)
     AND oh."id" = $2
     AND oh."status" = $4
-RETURNING oh."id",
+RETURNING
+    oh."id",
     oh."shipment",
     oh."total_price",
     oh."status",
@@ -1264,31 +1330,38 @@ func (q *Queries) SellerUpdateOrderStatus(ctx context.Context, arg SellerUpdateO
 }
 
 const sellerUpdateProductInfo = `-- name: SellerUpdateProductInfo :one
-UPDATE "product" p
-SET "name" = COALESCE($3, "name"),
+UPDATE
+    "product" p
+SET
+    "name" = COALESCE($3, "name"),
     "description" = COALESCE($4, "description"),
     "price" = COALESCE($5, "price"),
-    "image_id" = CASE
-        WHEN $9::TEXT = '' THEN "image_id"
-        ELSE $9::TEXT
+    "image_id" = CASE WHEN $9::TEXT = '' THEN
+        "image_id"
+    ELSE
+        $9::TEXT
     END,
     "expire_date" = COALESCE($6, "expire_date"),
     "enabled" = COALESCE($7, "enabled"),
     "stock" = COALESCE($8, "stock"),
     "edit_date" = NOW(),
     "version" = "version" + 1
-WHERE "shop_id" = (
-        SELECT s."id"
-        FROM "shop" s
-        WHERE s."seller_name" = $1
-            AND s."enabled" = true
-    )
+WHERE
+    "shop_id" =(
+        SELECT
+            s."id"
+        FROM
+            "shop" s
+        WHERE
+            s."seller_name" = $1
+            AND s."enabled" = TRUE)
     AND p."id" = $2
-RETURNING "id",
+RETURNING
+    "id",
     "name",
     "description",
     "price",
-    "image_id" as "image_url",
+    "image_id" AS "image_url",
     "expire_date",
     "edit_date",
     "stock",

--- a/db/test.sql.go
+++ b/db/test.sql.go
@@ -123,9 +123,10 @@ func (q *Queries) TestDeleteUserById(ctx context.Context, id int32) (int64, erro
 }
 
 const testInsertCart = `-- name: TestInsertCart :one
-INSERT INTO "cart" ("id", "user_id", "shop_id")
-VALUES ($1, $2, $3)
-RETURNING id, user_id, shop_id
+INSERT INTO "cart"("id", "user_id", "shop_id")
+    VALUES ($1, $2, $3)
+RETURNING
+    id, user_id, shop_id
 `
 
 type TestInsertCartParams struct {
@@ -142,9 +143,10 @@ func (q *Queries) TestInsertCart(ctx context.Context, arg TestInsertCartParams) 
 }
 
 const testInsertCartCoupon = `-- name: TestInsertCartCoupon :one
-INSERT INTO "cart_coupon" ("cart_id", "coupon_id")
-VALUES ($1, $2)
-RETURNING cart_id, coupon_id
+INSERT INTO "cart_coupon"("cart_id", "coupon_id")
+    VALUES ($1, $2)
+RETURNING
+    cart_id, coupon_id
 `
 
 type TestInsertCartCouponParams struct {
@@ -160,13 +162,10 @@ func (q *Queries) TestInsertCartCoupon(ctx context.Context, arg TestInsertCartCo
 }
 
 const testInsertCartProduct = `-- name: TestInsertCartProduct :one
-INSERT INTO "cart_product" (
-        "cart_id",
-        "product_id",
-        "quantity"
-    )
-VALUES ($1, $2, $3)
-RETURNING cart_id, product_id, quantity
+INSERT INTO "cart_product"("cart_id", "product_id", "quantity")
+    VALUES ($1, $2, $3)
+RETURNING
+    cart_id, product_id, quantity
 `
 
 type TestInsertCartProductParams struct {
@@ -183,19 +182,10 @@ func (q *Queries) TestInsertCartProduct(ctx context.Context, arg TestInsertCartP
 }
 
 const testInsertCoupon = `-- name: TestInsertCoupon :one
-INSERT INTO "coupon" (
-        "id",
-        "type",
-        "scope",
-        "shop_id",
-        "name",
-        "description",
-        "discount",
-        "start_date",
-        "expire_date"
-    )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-RETURNING id, type, scope, shop_id, name, description, discount, start_date, expire_date
+INSERT INTO "coupon"("id", "type", "scope", "shop_id", "name", "description", "discount", "start_date", "expire_date")
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING
+    id, type, scope, shop_id, name, description, discount, start_date, expire_date
 `
 
 type TestInsertCouponParams struct {
@@ -238,9 +228,10 @@ func (q *Queries) TestInsertCoupon(ctx context.Context, arg TestInsertCouponPara
 }
 
 const testInsertCouponTag = `-- name: TestInsertCouponTag :one
-INSERT INTO "coupon_tag" ("tag_id", "coupon_id")
-VALUES ($1, $2)
-RETURNING coupon_id, tag_id
+INSERT INTO "coupon_tag"("tag_id", "coupon_id")
+    VALUES ($1, $2)
+RETURNING
+    coupon_id, tag_id
 `
 
 type TestInsertCouponTagParams struct {
@@ -256,14 +247,10 @@ func (q *Queries) TestInsertCouponTag(ctx context.Context, arg TestInsertCouponT
 }
 
 const testInsertOrderDetail = `-- name: TestInsertOrderDetail :one
-INSERT INTO "order_detail" (
-        "order_id",
-        "product_id",
-        "product_version",
-        "quantity"
-    )
-VALUES ($1, $2, $3, $4)
-RETURNING order_id, product_id, product_version, quantity
+INSERT INTO "order_detail"("order_id", "product_id", "product_version", "quantity")
+    VALUES ($1, $2, $3, $4)
+RETURNING
+    order_id, product_id, product_version, quantity
 `
 
 type TestInsertOrderDetailParams struct {
@@ -291,24 +278,16 @@ func (q *Queries) TestInsertOrderDetail(ctx context.Context, arg TestInsertOrder
 }
 
 const testInsertOrderHistory = `-- name: TestInsertOrderHistory :one
-INSERT INTO "order_history" (
-        "id",
-        "user_id",
-        "shop_id",
-        "image_id",
-        "shipment",
-        "total_price",
-        "status"
-    )
-VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, user_id, shop_id, image_id, shipment, total_price, status, created_at
+INSERT INTO "order_history"("id", "user_id", "shop_id", "shipment", "total_price", "status")
+    VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING
+    id, user_id, shop_id, shipment, total_price, status, created_at
 `
 
 type TestInsertOrderHistoryParams struct {
 	ID         int32       `json:"id" param:"id"`
 	UserID     int32       `json:"user_id"`
 	ShopID     int32       `json:"shop_id"`
-	ImageID    string      `json:"image_id"`
 	Shipment   int32       `json:"shipment"`
 	TotalPrice int32       `json:"total_price"`
 	Status     OrderStatus `json:"status"`
@@ -319,7 +298,6 @@ func (q *Queries) TestInsertOrderHistory(ctx context.Context, arg TestInsertOrde
 		arg.ID,
 		arg.UserID,
 		arg.ShopID,
-		arg.ImageID,
 		arg.Shipment,
 		arg.TotalPrice,
 		arg.Status,
@@ -329,7 +307,6 @@ func (q *Queries) TestInsertOrderHistory(ctx context.Context, arg TestInsertOrde
 		&i.ID,
 		&i.UserID,
 		&i.ShopID,
-		&i.ImageID,
 		&i.Shipment,
 		&i.TotalPrice,
 		&i.Status,
@@ -339,35 +316,10 @@ func (q *Queries) TestInsertOrderHistory(ctx context.Context, arg TestInsertOrde
 }
 
 const testInsertProduct = `-- name: TestInsertProduct :one
-INSERT INTO "product" (
-        "id",
-        "version",
-        "shop_id",
-        "name",
-        "description",
-        "price",
-        "image_id",
-        "expire_date",
-        "edit_date",
-        "stock",
-        "sales",
-        "enabled"
-    )
-VALUES (
-        $1,
-        $2,
-        $3,
-        $4,
-        $5,
-        $6,
-        $7,
-        NOW(),
-        $8,
-        $9,
-        $10,
-        $11
-    )
-RETURNING id, version, shop_id, name, description, price, image_id, expire_date, edit_date, stock, sales, enabled
+INSERT INTO "product"("id", "version", "shop_id", "name", "description", "price", "image_id", "expire_date", "edit_date", "stock", "sales", "enabled")
+    VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8, $9, $10, $11)
+RETURNING
+    id, version, shop_id, name, description, price, image_id, expire_date, edit_date, stock, sales, enabled
 `
 
 type TestInsertProductParams struct {
@@ -417,16 +369,10 @@ func (q *Queries) TestInsertProduct(ctx context.Context, arg TestInsertProductPa
 }
 
 const testInsertProductArchive = `-- name: TestInsertProductArchive :one
-INSERT INTO "product_archive" (
-        "id",
-        "version",
-        "name",
-        "description",
-        "price",
-        "image_id"
-    )
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, version, name, description, price, image_id
+INSERT INTO "product_archive"("id", "version", "name", "description", "price", "image_id")
+    VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING
+    id, version, name, description, price, image_id
 `
 
 type TestInsertProductArchiveParams struct {
@@ -460,9 +406,10 @@ func (q *Queries) TestInsertProductArchive(ctx context.Context, arg TestInsertPr
 }
 
 const testInsertProductTag = `-- name: TestInsertProductTag :one
-INSERT INTO "product_tag" ("tag_id", "product_id")
-VALUES ($1, $2)
-RETURNING tag_id, product_id
+INSERT INTO "product_tag"("tag_id", "product_id")
+    VALUES ($1, $2)
+RETURNING
+    tag_id, product_id
 `
 
 type TestInsertProductTagParams struct {
@@ -478,16 +425,10 @@ func (q *Queries) TestInsertProductTag(ctx context.Context, arg TestInsertProduc
 }
 
 const testInsertShop = `-- name: TestInsertShop :one
-INSERT INTO "shop" (
-        "id",
-        "seller_name",
-        "name",
-        "image_id",
-        "description",
-        "enabled"
-    )
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, seller_name, image_id, name, description, enabled
+INSERT INTO "shop"("id", "seller_name", "name", "image_id", "description", "enabled")
+    VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING
+    id, seller_name, image_id, name, description, enabled
 `
 
 type TestInsertShopParams struct {
@@ -521,9 +462,10 @@ func (q *Queries) TestInsertShop(ctx context.Context, arg TestInsertShopParams) 
 }
 
 const testInsertTag = `-- name: TestInsertTag :one
-INSERT INTO "tag" ("id", "shop_id", "name")
-VALUES ($1, $2, $3)
-RETURNING id, shop_id, name
+INSERT INTO "tag"("id", "shop_id", "name")
+    VALUES ($1, $2, $3)
+RETURNING
+    id, shop_id, name
 `
 
 type TestInsertTagParams struct {
@@ -540,21 +482,10 @@ func (q *Queries) TestInsertTag(ctx context.Context, arg TestInsertTagParams) (T
 }
 
 const testInsertUser = `-- name: TestInsertUser :one
-INSERT INTO "user" (
-        "id",
-        "username",
-        "password",
-        "name",
-        "email",
-        "address",
-        "image_id",
-        "role",
-        "credit_card",
-        "refresh_token",
-        "enabled"
-    )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, username, password, name, email, address, image_id, role, credit_card, refresh_token, enabled, refresh_token_expire_date
+INSERT INTO "user"("id", "username", "password", "name", "email", "address", "image_id", "role", "credit_card", "refresh_token", "enabled")
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+RETURNING
+    id, username, password, name, email, address, image_id, role, credit_card, refresh_token, enabled, refresh_token_expire_date
 `
 
 type TestInsertUserParams struct {

--- a/db/user.sql.go
+++ b/db/user.sql.go
@@ -13,20 +13,8 @@ import (
 )
 
 const addShop = `-- name: AddShop :exec
-INSERT INTO "shop" (
-        "seller_name",
-        "image_id",
-        "name",
-        "description",
-        "enabled"
-    )
-VALUES(
-        $1,
-        NULL,
-        $2,
-        '',
-        FALSE
-    )
+INSERT INTO "shop"("seller_name", "image_id", "name", "description", "enabled")
+    VALUES ($1, '', $2, '', FALSE)
 `
 
 type AddShopParams struct {
@@ -40,26 +28,8 @@ func (q *Queries) AddShop(ctx context.Context, arg AddShopParams) error {
 }
 
 const addUser = `-- name: AddUser :exec
-INSERT INTO "user" (
-        "username",
-        "password",
-        "name",
-        "email",
-        "address",
-        "role",
-        "credit_card",
-        "enabled"
-    )
-VALUES (
-        $1,
-        $2,
-        $3,
-        $4,
-        $5,
-        'customer',
-        '{}',
-        TRUE
-    )
+INSERT INTO "user"("username", "password", "name", "email", "address", "role", "credit_card", "enabled", "image_id")
+    VALUES ($1, $2, $3, $4, $5, 'customer', '{}', TRUE, '')
 `
 
 type AddUserParams struct {
@@ -82,9 +52,12 @@ func (q *Queries) AddUser(ctx context.Context, arg AddUserParams) error {
 }
 
 const deleteRefreshToken = `-- name: DeleteRefreshToken :exec
-UPDATE "user"
-SET "refresh_token" = NULL
-WHERE "refresh_token" = $1
+UPDATE
+    "user"
+SET
+    "refresh_token" = NULL
+WHERE
+    "refresh_token" = $1
 `
 
 func (q *Queries) DeleteRefreshToken(ctx context.Context, refreshToken string) error {
@@ -93,10 +66,13 @@ func (q *Queries) DeleteRefreshToken(ctx context.Context, refreshToken string) e
 }
 
 const findUserByRefreshToken = `-- name: FindUserByRefreshToken :one
-SELECT "username",
+SELECT
+    "username",
     "role"
-FROM "user"
-WHERE "refresh_token" = $1
+FROM
+    "user"
+WHERE
+    "refresh_token" = $1
     AND "refresh_token_expire_date" > NOW()
 `
 
@@ -113,11 +89,14 @@ func (q *Queries) FindUserByRefreshToken(ctx context.Context, refreshToken strin
 }
 
 const findUserInfoAndPassword = `-- name: FindUserInfoAndPassword :one
-SELECT "username",
+SELECT
+    "username",
     "role",
     "password"
-FROM "user"
-WHERE "username" = $1
+FROM
+    "user"
+WHERE
+    "username" = $1
     OR "email" = $1
 `
 
@@ -137,10 +116,13 @@ func (q *Queries) FindUserInfoAndPassword(ctx context.Context, username string) 
 }
 
 const setRefreshToken = `-- name: SetRefreshToken :exec
-UPDATE "user"
-SET "refresh_token" = $1,
+UPDATE
+    "user"
+SET
+    "refresh_token" = $1,
     "refresh_token_expire_date" = $2
-WHERE "username" = $3
+WHERE
+    "username" = $3
 `
 
 type SetRefreshTokenParams struct {
@@ -155,12 +137,15 @@ func (q *Queries) SetRefreshToken(ctx context.Context, arg SetRefreshTokenParams
 }
 
 const userExists = `-- name: UserExists :one
-SELECT EXISTS (
-        SELECT 1
-        FROM "user"
-        WHERE "username" = $1
-            OR "email" = $2
-    )
+SELECT
+    EXISTS (
+        SELECT
+            1
+        FROM
+            "user"
+        WHERE
+            "username" = $1
+            OR "email" = $2)
 `
 
 type UserExistsParams struct {
@@ -176,9 +161,12 @@ func (q *Queries) UserExists(ctx context.Context, arg UserExistsParams) (bool, e
 }
 
 const userGetCreditCard = `-- name: UserGetCreditCard :one
-SELECT "credit_card"
-FROM "user"
-WHERE "username" = $1
+SELECT
+    "credit_card"
+FROM
+    "user"
+WHERE
+    "username" = $1
 `
 
 func (q *Queries) UserGetCreditCard(ctx context.Context, username string) (json.RawMessage, error) {
@@ -189,12 +177,15 @@ func (q *Queries) UserGetCreditCard(ctx context.Context, username string) (json.
 }
 
 const userGetInfo = `-- name: UserGetInfo :one
-SELECT "name",
+SELECT
+    "name",
     "email",
     "address",
-    "image_id" as "image_url"
-FROM "user" u
-WHERE u."username" = $1
+    "image_id" AS "image_url"
+FROM
+    "user" u
+WHERE
+    u."username" = $1
 `
 
 type UserGetInfoRow struct {
@@ -217,9 +208,12 @@ func (q *Queries) UserGetInfo(ctx context.Context, username string) (UserGetInfo
 }
 
 const userGetPassword = `-- name: UserGetPassword :one
-SELECT "password"
-FROM "user"
-WHERE "username" = $1
+SELECT
+    "password"
+FROM
+    "user"
+WHERE
+    "username" = $1
 `
 
 func (q *Queries) UserGetPassword(ctx context.Context, username string) (string, error) {
@@ -230,10 +224,14 @@ func (q *Queries) UserGetPassword(ctx context.Context, username string) (string,
 }
 
 const userUpdateCreditCard = `-- name: UserUpdateCreditCard :one
-UPDATE "user"
-SET "credit_card" = $2
-WHERE "username" = $1
-RETURNING "credit_card"
+UPDATE
+    "user"
+SET
+    "credit_card" = $2
+WHERE
+    "username" = $1
+RETURNING
+    "credit_card"
 `
 
 type UserUpdateCreditCardParams struct {
@@ -249,19 +247,24 @@ func (q *Queries) UserUpdateCreditCard(ctx context.Context, arg UserUpdateCredit
 }
 
 const userUpdateInfo = `-- name: UserUpdateInfo :one
-UPDATE "user"
-SET "name" = COALESCE($2, "name"),
+UPDATE
+    "user"
+SET
+    "name" = COALESCE($2, "name"),
     "email" = COALESCE($3, "email"),
     "address" = COALESCE($4, "address"),
-    "image_id" = CASE
-        WHEN $5::TEXT = '' THEN "image_id"
-        ELSE $5::TEXT
+    "image_id" = CASE WHEN $5::TEXT = '' THEN
+        "image_id"
+    ELSE
+        $5::TEXT
     END
-WHERE "username" = $1
-RETURNING "name",
+WHERE
+    "username" = $1
+RETURNING
+    "name",
     "email",
     "address",
-    "image_id" as "image_url"
+    "image_id" AS "image_url"
 `
 
 type UserUpdateInfoParams struct {
@@ -298,13 +301,17 @@ func (q *Queries) UserUpdateInfo(ctx context.Context, arg UserUpdateInfoParams) 
 }
 
 const userUpdatePassword = `-- name: UserUpdatePassword :one
-UPDATE "user"
-SET "password" = $2
-WHERE "username" = $1
-RETURNING "name",
+UPDATE
+    "user"
+SET
+    "password" = $2
+WHERE
+    "username" = $1
+RETURNING
+    "name",
     "email",
     "address",
-    "image_id" as "image_url"
+    "image_id" AS "image_url"
 `
 
 type UserUpdatePasswordParams struct {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4138,9 +4138,6 @@ const docTemplate = `{
                 "status": {
                     "$ref": "#/definitions/db.OrderStatus"
                 },
-                "thumbnail_url": {
-                    "type": "string"
-                },
                 "total_price": {
                     "type": "integer"
                 },
@@ -4163,9 +4160,6 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "integer"
-                },
-                "image_url": {
-                    "type": "string"
                 },
                 "shipment": {
                     "type": "integer"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4132,9 +4132,6 @@
                 "status": {
                     "$ref": "#/definitions/db.OrderStatus"
                 },
-                "thumbnail_url": {
-                    "type": "string"
-                },
                 "total_price": {
                     "type": "integer"
                 },
@@ -4157,9 +4154,6 @@
                 },
                 "id": {
                     "type": "integer"
-                },
-                "image_url": {
-                    "type": "string"
                 },
                 "shipment": {
                     "type": "integer"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -638,8 +638,6 @@ definitions:
         type: integer
       status:
         $ref: '#/definitions/db.OrderStatus'
-      thumbnail_url:
-        type: string
       total_price:
         type: integer
       user_id:
@@ -655,8 +653,6 @@ definitions:
         type: string
       id:
         type: integer
-      image_url:
-        type: string
       shipment:
         type: integer
       status:

--- a/pkg/router/admin/coupon.go
+++ b/pkg/router/admin/coupon.go
@@ -95,7 +95,7 @@ func AddCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 			logger.Errorw("failed to parse discount", "error", err)
 			return echo.NewHTTPError(http.StatusBadRequest, "Invalid discount")
 		}
-		if discount.Float64 < 0 || (coupon.Type == db.CouponTypeFixed && discount.Float64 > 100) {
+		if discount.Float64 < 0 || (coupon.Type == db.CouponTypePercentage && discount.Float64 > 100) {
 			logger.Errorw("discount is invalid", "discount", discount)
 			return echo.NewHTTPError(http.StatusBadRequest, "Discount is invalid")
 		}

--- a/pkg/router/buyer/checkout.go
+++ b/pkg/router/buyer/checkout.go
@@ -126,7 +126,7 @@ func GetCheckout(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 			cd.Discount = discount.Float64
 			// if coupon is shipping coupon, calculate discount and continue
 			if cd.Type == db.CouponTypeShipping {
-				cd.DiscountValue = result.Shipment * (int32(cd.Discount / 100))
+				cd.DiscountValue = result.Shipment
 				totalDiscount += cd.DiscountValue
 				result.Coupons = append(result.Coupons, cd)
 				continue
@@ -269,7 +269,7 @@ func Checkout(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 			}
 			dc := discount.Float64
 			if coupon.Type == db.CouponTypeShipping {
-				totalDiscount += shipment * (int32(dc / 100))
+				totalDiscount += shipment
 				continue
 			}
 			tags, err := pg.Queries.GetCouponTag(c.Request().Context(), coupon.ID)

--- a/pkg/router/seller/order.go
+++ b/pkg/router/seller/order.go
@@ -52,6 +52,7 @@ func GetOrder(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.HandlerFu
 			logger.Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
+		// FIX ME
 		// for i := range orders {
 		// 	orders[i].ImageUrl = mc.GetFileURL(c.Request().Context(), orders[i].ImageUrl)
 		// }

--- a/pkg/router/seller/order.go
+++ b/pkg/router/seller/order.go
@@ -52,9 +52,9 @@ func GetOrder(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.HandlerFu
 			logger.Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
-		for i := range orders {
-			orders[i].ImageUrl = mc.GetFileURL(c.Request().Context(), orders[i].ImageUrl)
-		}
+		// for i := range orders {
+		// 	orders[i].ImageUrl = mc.GetFileURL(c.Request().Context(), orders[i].ImageUrl)
+		// }
 		return c.JSON(http.StatusOK, orders)
 	}
 }
@@ -92,7 +92,7 @@ func GetOrderDetail(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.Han
 			logger.Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
-		result.OrderInfo.ThumbnailUrl = mc.GetFileURL(c.Request().Context(), result.OrderInfo.ThumbnailUrl)
+		// result.OrderInfo.ThumbnailUrl = mc.GetFileURL(c.Request().Context(), result.OrderInfo.ThumbnailUrl)
 		result.OrderInfo.UserImageUrl = mc.GetFileURL(c.Request().Context(), result.OrderInfo.UserImageUrl)
 		for i := range result.Products {
 			result.Products[i].ImageUrl = mc.GetFileURL(c.Request().Context(), result.Products[i].ImageUrl)

--- a/pkg/router/seller/order.go
+++ b/pkg/router/seller/order.go
@@ -93,6 +93,7 @@ func GetOrderDetail(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.Han
 			logger.Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
+		// FIX ME
 		// result.OrderInfo.ThumbnailUrl = mc.GetFileURL(c.Request().Context(), result.OrderInfo.ThumbnailUrl)
 		result.OrderInfo.UserImageUrl = mc.GetFileURL(c.Request().Context(), result.OrderInfo.UserImageUrl)
 		for i := range result.Products {

--- a/test/db/main.go
+++ b/test/db/main.go
@@ -21,7 +21,7 @@ func main() {
 	defer pg.Close()
 
 	TestInsertData(pg)
-	TestDeleteData(pg)
+	// TestDeleteData(pg)
 }
 
 type testTable struct {

--- a/test/db/main.go
+++ b/test/db/main.go
@@ -21,7 +21,7 @@ func main() {
 	defer pg.Close()
 
 	TestInsertData(pg)
-	// TestDeleteData(pg)
+	TestDeleteData(pg)
 }
 
 type testTable struct {


### PR DESCRIPTION
<!-- Description or Related Issues -->
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fix #103, Fix #104, Fix #111

### Changes
> 無情的修改資料庫綱要並假裝綱要遷移並不存在

#103 將綱要中所有的 `"image_id" TEXT` 改為 `"image_id" TEXT NOT NULL`，並讓空字串交給`minio`相關函數處理，並且理論上前端在接到空字串時會將其換成預設的相關圖片。
#104 如議題所述，為了正規化綱要 (3NF) 及統一設計模式，將 `"thumbnail_id"` 從 `order_history` 中移除。
#111 如議題所述，免運券應直接進行免運，不需再乘上 `Percentage`，所以在`buyer/order.go` 修正 https://github.com/jykuo-love-shiritori/twp/pull/105/commits/a858262b0f1af9ef5bc5080dee39e9b7e2a3f230