### PR TITLE
[backend] Fix disable user return wrong message

### DIFF
--- a/db/admin.sql.go
+++ b/db/admin.sql.go
@@ -113,7 +113,7 @@ func (q *Queries) DisableProductsFromShop(ctx context.Context, shopID int32) (in
 	return result.RowsAffected(), nil
 }
 
-const disableShop = `-- name: DisableShop :execrows
+const disableShop = `-- name: DisableShop :exec
 WITH disable_shop AS (
     UPDATE
         "shop"
@@ -135,48 +135,20 @@ WHERE
             disable_shop)
 `
 
-func (q *Queries) DisableShop(ctx context.Context, sellerName string) (int64, error) {
-	result, err := q.db.Exec(ctx, disableShop, sellerName)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+func (q *Queries) DisableShop(ctx context.Context, sellerName string) error {
+	_, err := q.db.Exec(ctx, disableShop, sellerName)
+	return err
 }
 
 const disableUser = `-- name: DisableUser :execrows
-WITH disabled_user AS (
-    UPDATE
-        "user"
-    SET
-        "enabled" = FALSE
-    WHERE
-        "username" = $1
-    RETURNING
-        "username"
-),
-disabled_shop AS (
-    UPDATE
-        "shop"
-    SET
-        "enabled" = FALSE
-    WHERE
-        "seller_name" =(
-            SELECT
-                "username"
-            FROM
-                disabled_user)
-        RETURNING
-            "id")
 UPDATE
-    "product"
+    "user"
 SET
     "enabled" = FALSE
 WHERE
-    "shop_id" =(
-        SELECT
-            "id"
-        FROM
-            disabled_shop)
+    "username" = $1
+RETURNING
+    "username"
 `
 
 func (q *Queries) DisableUser(ctx context.Context, username string) (int64, error) {

--- a/db/queries/admin.sql
+++ b/db/queries/admin.sql
@@ -25,41 +25,16 @@ WHERE
     "seller_name" = $1;
 
 -- name: DisableUser :execrows
-WITH disabled_user AS (
-    UPDATE
-        "user"
-    SET
-        "enabled" = FALSE
-    WHERE
-        "username" = $1
-    RETURNING
-        "username"
-),
-disabled_shop AS (
-    UPDATE
-        "shop"
-    SET
-        "enabled" = FALSE
-    WHERE
-        "seller_name" =(
-            SELECT
-                "username"
-            FROM
-                disabled_user)
-        RETURNING
-            "id")
 UPDATE
-    "product"
+    "user"
 SET
     "enabled" = FALSE
 WHERE
-    "shop_id" =(
-        SELECT
-            "id"
-        FROM
-            disabled_shop);
+    "username" = $1
+RETURNING
+    "username";
 
--- name: DisableShop :execrows
+-- name: DisableShop :exec
 WITH disable_shop AS (
     UPDATE
         "shop"


### PR DESCRIPTION
<!-- Description or Related Issues -->
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Resolves #119
### Changes
The issue is come from that using multiple subquery in one sql query. And the `:execrows` only return the last query's executing rows. While `execrows` is currently use to determine the username existence. 
Hence, I move out the disable user query form original query, and use transactions to complete the procedure.
PS: Due to disable user would make its shop and shop's products unavailable. So it needs multiple `UPDATE` query
<!-- List the changes introduced by this pull request. -->


### Testing Approach (if unconventional)
<!-- Describe how you tested your changes, including details of your testing environment and the tests you ran to evaluate the impact on other code areas. -->
Insert the dummy data into db
Signup any user with `{username}` and call `DELETE localhost:8080/api/admin/user/{username}`.
It should return `🎉success🎉`. And the `enabled` column of `{username}` in db should be `FALSE`
You may also call `DELETE localhost:8080/api/admin/user/Seller`. And check db that its corresponding shop and products' `enabled` should be `FALSE` too. 
