### PR TITLE
Fix coupon start date can't be today

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1272,10 +1272,10 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
-                            "\"price\"",
-                            "\"stock\"",
-                            "\"sales\"",
-                            "\"relevancy\""
+                            "price",
+                            "stock",
+                            "sales",
+                            "relevancy"
                         ],
                         "type": "string",
                         "description": "sort by",
@@ -1284,8 +1284,8 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
-                            "\"asc\"",
-                            "\"desc\""
+                            "asc",
+                            "desc"
                         ],
                         "type": "string",
                         "description": "sorting order",
@@ -2378,7 +2378,7 @@ const docTemplate = `{
                 "summary": "Seller add product tag",
                 "parameters": [
                     {
-                        "type": "integer",
+                        "type": "string",
                         "description": "product id",
                         "name": "id",
                         "in": "path",
@@ -2390,7 +2390,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/seller.GetTagParams"
+                            "$ref": "#/definitions/seller.TagParams"
                         }
                     }
                 ],
@@ -2813,10 +2813,10 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
-                            "\"price\"",
-                            "\"stock\"",
-                            "\"sales\"",
-                            "\"relevancy\""
+                            "price",
+                            "stock",
+                            "sales",
+                            "relevancy"
                         ],
                         "type": "string",
                         "description": "sort by",
@@ -2825,8 +2825,8 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
-                            "\"asc\"",
-                            "\"desc\""
+                            "asc",
+                            "desc"
                         ],
                         "type": "string",
                         "description": "sorting order",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1266,10 +1266,10 @@
                     },
                     {
                         "enum": [
-                            "\"price\"",
-                            "\"stock\"",
-                            "\"sales\"",
-                            "\"relevancy\""
+                            "price",
+                            "stock",
+                            "sales",
+                            "relevancy"
                         ],
                         "type": "string",
                         "description": "sort by",
@@ -1278,8 +1278,8 @@
                     },
                     {
                         "enum": [
-                            "\"asc\"",
-                            "\"desc\""
+                            "asc",
+                            "desc"
                         ],
                         "type": "string",
                         "description": "sorting order",
@@ -2372,7 +2372,7 @@
                 "summary": "Seller add product tag",
                 "parameters": [
                     {
-                        "type": "integer",
+                        "type": "string",
                         "description": "product id",
                         "name": "id",
                         "in": "path",
@@ -2384,7 +2384,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/seller.GetTagParams"
+                            "$ref": "#/definitions/seller.TagParams"
                         }
                     }
                 ],
@@ -2807,10 +2807,10 @@
                     },
                     {
                         "enum": [
-                            "\"price\"",
-                            "\"stock\"",
-                            "\"sales\"",
-                            "\"relevancy\""
+                            "price",
+                            "stock",
+                            "sales",
+                            "relevancy"
                         ],
                         "type": "string",
                         "description": "sort by",
@@ -2819,8 +2819,8 @@
                     },
                     {
                         "enum": [
-                            "\"asc\"",
-                            "\"desc\""
+                            "asc",
+                            "desc"
                         ],
                         "type": "string",
                         "description": "sorting order",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1922,17 +1922,17 @@ paths:
         type: boolean
       - description: sort by
         enum:
-        - '"price"'
-        - '"stock"'
-        - '"sales"'
-        - '"relevancy"'
+        - price
+        - stock
+        - sales
+        - relevancy
         in: query
         name: sortBy
         type: string
       - description: sorting order
         enum:
-        - '"asc"'
-        - '"desc"'
+        - asc
+        - desc
         in: query
         name: order
         type: string
@@ -2725,13 +2725,13 @@ paths:
         in: path
         name: id
         required: true
-        type: integer
+        type: string
       - description: add tag id
         in: body
         name: tag_id
         required: true
         schema:
-          $ref: '#/definitions/seller.GetTagParams'
+          $ref: '#/definitions/seller.TagParams'
       produces:
       - application/json
       responses:
@@ -2978,17 +2978,17 @@ paths:
         type: boolean
       - description: sort by
         enum:
-        - '"price"'
-        - '"stock"'
-        - '"sales"'
-        - '"relevancy"'
+        - price
+        - stock
+        - sales
+        - relevancy
         in: query
         name: sortBy
         type: string
       - description: sorting order
         enum:
-        - '"asc"'
-        - '"desc"'
+        - asc
+        - desc
         in: query
         name: order
         type: string

--- a/pkg/router/admin/coupon.go
+++ b/pkg/router/admin/coupon.go
@@ -92,7 +92,7 @@ func AddCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusBadRequest)
 		}
 		// if the the given time is invalid, make it become now 😇
-		if coupon.StartDate.Time.Before(time.Now().Truncate(24 * time.Hour)) {
+		if coupon.StartDate.Time.Before(time.Now()) {
 			coupon.StartDate.Time = time.Now()
 		}
 		if coupon.ExpireDate.Time.Before(coupon.StartDate.Time) {

--- a/pkg/router/admin/coupon.go
+++ b/pkg/router/admin/coupon.go
@@ -95,6 +95,15 @@ func AddCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 			logger.Errorw("start date is invalid", "start date", coupon.StartDate)
 			return echo.NewHTTPError(http.StatusBadRequest, "Start date is invalid")
 		}
+		discount, err := coupon.Discount.Float64Value()
+		if err != nil {
+			logger.Errorw("failed to parse discount", "error", err)
+			return echo.NewHTTPError(http.StatusBadRequest, "Invalid discount")
+		}
+		if discount.Float64 < 0 || (coupon.Type == db.CouponTypePercentage && discount.Float64 > 100) {
+			logger.Errorw("discount is invalid", "discount", discount)
+			return echo.NewHTTPError(http.StatusBadRequest, "Discount is invalid")
+		}
 		coupon.Scope = "global"
 		result, err := pg.Queries.AddCoupon(c.Request().Context(), coupon)
 		if err != nil {

--- a/pkg/router/admin/coupon.go
+++ b/pkg/router/admin/coupon.go
@@ -92,8 +92,8 @@ func AddCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusBadRequest)
 		}
 		// if the the given time is invalid, make it become now 😇
-		if coupon.ExpireDate.Time.Before(time.Now().Truncate(24 * time.Hour)) {
-			coupon.ExpireDate.Time = time.Now()
+		if coupon.StartDate.Time.Before(time.Now().Truncate(24 * time.Hour)) {
+			coupon.StartDate.Time = time.Now()
 		}
 		if coupon.ExpireDate.Time.Before(coupon.StartDate.Time) {
 			logger.Errorw("start date is invalid", "start date", coupon.StartDate)
@@ -156,7 +156,7 @@ func EditCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 		}
 		// if the the given time is invalid, make it become now 😇
 		if coupon.StartDate.Time.Before(time.Now()) {
-			coupon.ExpireDate.Time = time.Now()
+			coupon.StartDate.Time = time.Now()
 		}
 		if coupon.ExpireDate.Time.Before(coupon.StartDate.Time) {
 			logger.Errorw("start date should later than ", "start date", coupon.StartDate)

--- a/pkg/router/general/search.go
+++ b/pkg/router/general/search.go
@@ -78,8 +78,8 @@ type searchResult struct {
 // @Param			minStock	query		int		false	"stock lower bound"
 // @Param			maxStock	query		int		false	"stock upper bound"
 // @Param			haveCoupon	query		bool	false	"has coupon"
-// @Param			sortBy		query		string	false	"sort by"		Enums("price", "stock", "sales", "relevancy")
-// @Param			order		query		string	false	"sorting order"	Enums("asc", "desc")
+// @Param			sortBy		query		string	false	"sort by"		Enums(price, stock, sales, relevancy)
+// @Param			order		query		string	false	"sorting order"	Enums(asc, desc)
 // @Param			offset		query		int		false	"Begin index"	default(0)
 // @Param			limit		query		int		false	"limit"			default(10)	Maximum(20)
 // @Success		200			{object}	PrettierProductSearchResult
@@ -165,8 +165,8 @@ func SearchShopProduct(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.
 // @Param			minStock	query		int		false	"stock lower bound"
 // @Param			maxStock	query		int		false	"stock upper bound"
 // @Param			haveCoupon	query		bool	false	"has coupon"
-// @Param			sortBy		query		string	false	"sort by"		Enums("price", "stock", "sales", "relevancy")
-// @Param			order		query		string	false	"sorting order"	Enums("asc", "desc")
+// @Param			sortBy		query		string	false	"sort by"		Enums(price, stock, sales, relevancy)
+// @Param			order		query		string	false	"sorting order"	Enums(asc, desc)
 // @Param			offset		query		int		false	"Begin index"	default(0)
 // @Param			limit		query		int		false	"limit"			default(10)	Maximum(20)
 // @Success		200			{object}	PrettierSearchResult

--- a/pkg/router/seller/coupon.go
+++ b/pkg/router/seller/coupon.go
@@ -128,7 +128,7 @@ func AddCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusBadRequest)
 		}
 		//check expire time
-		if param.ExpireDate.Time.Before(param.StartDate.Time) || param.ExpireDate.Time.Before(time.Now()) || param.StartDate.Time.Before(time.Now()) {
+		if param.StartDate.Time.Before(time.Now().Truncate(24*time.Hour)) || param.ExpireDate.Time.Before(param.StartDate.Time) {
 			logger.Errorw("expire date or start date is invalid")
 			return echo.NewHTTPError(http.StatusBadRequest)
 		}
@@ -181,7 +181,7 @@ func EditCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 
 		}
 		//check expire time
-		if param.ExpireDate.Time.Before(param.StartDate.Time) || param.ExpireDate.Time.Before(time.Now()) || param.StartDate.Time.Before(time.Now()) {
+		if param.StartDate.Time.Before(time.Now().Truncate(24*time.Hour)) || param.ExpireDate.Time.Before(param.StartDate.Time) {
 			logger.Errorw("expire date or start date is invalid")
 			return echo.NewHTTPError(http.StatusBadRequest)
 		}

--- a/pkg/router/seller/coupon.go
+++ b/pkg/router/seller/coupon.go
@@ -128,9 +128,12 @@ func AddCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusBadRequest)
 		}
 		//check expire time
-		if param.StartDate.Time.Before(time.Now().Truncate(24*time.Hour)) || param.ExpireDate.Time.Before(param.StartDate.Time) {
-			logger.Errorw("expire date or start date is invalid")
-			return echo.NewHTTPError(http.StatusBadRequest)
+		if param.StartDate.Time.Before(time.Now()) {
+			param.ExpireDate.Time = time.Now()
+		}
+		if param.ExpireDate.Time.Before(param.StartDate.Time) {
+			logger.Errorw("expire date is invalid", "start date", param.StartDate)
+			return echo.NewHTTPError(http.StatusBadRequest, "expire date is invalid")
 		}
 		//check discount value
 		if v, err := param.Discount.Float64Value(); err != nil || v.Float64 < 0 || (param.Type == db.CouponTypePercentage && v.Float64 > 100) {
@@ -181,9 +184,12 @@ func EditCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 
 		}
 		//check expire time
-		if param.StartDate.Time.Before(time.Now().Truncate(24*time.Hour)) || param.ExpireDate.Time.Before(param.StartDate.Time) {
-			logger.Errorw("expire date or start date is invalid")
-			return echo.NewHTTPError(http.StatusBadRequest)
+		if param.StartDate.Time.Before(time.Now()) {
+			param.ExpireDate.Time = time.Now()
+		}
+		if param.ExpireDate.Time.Before(param.StartDate.Time) {
+			logger.Errorw("expire date is invalid", "start date", param.StartDate)
+			return echo.NewHTTPError(http.StatusBadRequest, "expire date is invalid")
 		}
 		//check discount value
 		if v, err := param.Discount.Float64Value(); err != nil || v.Float64 < 0 || (param.Type == db.CouponTypePercentage && v.Float64 > 100) {

--- a/pkg/router/seller/coupon.go
+++ b/pkg/router/seller/coupon.go
@@ -127,9 +127,9 @@ func AddCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 			logger.Errorw("tags is invalid")
 			return echo.NewHTTPError(http.StatusBadRequest)
 		}
-		//check expire time
+		//check start/expire time
 		if param.StartDate.Time.Before(time.Now()) {
-			param.ExpireDate.Time = time.Now()
+			param.StartDate.Time = time.Now()
 		}
 		if param.ExpireDate.Time.Before(param.StartDate.Time) {
 			logger.Errorw("expire date is invalid", "start date", param.StartDate)
@@ -183,9 +183,9 @@ func EditCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusBadRequest)
 
 		}
-		//check expire time
+		//check start/expire time
 		if param.StartDate.Time.Before(time.Now()) {
-			param.ExpireDate.Time = time.Now()
+			param.StartDate.Time = time.Now()
 		}
 		if param.ExpireDate.Time.Before(param.StartDate.Time) {
 			logger.Errorw("expire date is invalid", "start date", param.StartDate)


### PR DESCRIPTION
<!-- Description or Related Issues -->
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Resolves #128

### Changes

- Let start date can be today 
### Testing Approach (if unconventional)
```
curl -X 'POST' \ 'http://localhost:8080/api/seller/coupon' \ -H 'accept: application/json' \ -H 'Content-Type: application/json' \ -d '{ "description": "some description", "discount": 19.99, "expire_date": "2024-11-12T07:20:50.52Z", "name": "product name", "start_date": "2024-01-03T00:00:00+07:00", "tags": [ 10001, 10002 ], "type": "fixed" }'
curl -X 'POST' \ 'http://localhost:8080/api/admin/coupon' \ -H 'accept: application/json' \ -H 'Content-Type: application/json' \ -d '{ "description": "string", "discount": 10, "expire_date": "2024-11-24T12:00:00Z", "name": "string", "scope": "global", "start_date": "2022-11-03T01:00:00+08:00", "type": "percentage" }'
```
