### PR TITLE
[backend] Fix #139 and #142

### DIFF
--- a/db/general.sql.go
+++ b/db/general.sql.go
@@ -65,6 +65,43 @@ func (q *Queries) GetProductInfo(ctx context.Context, id int32) (GetProductInfoR
 	return i, err
 }
 
+const getProductTags = `-- name: GetProductTags :many
+SELECT
+    T."id",
+    T."name"
+FROM
+    "tag" T,
+    "product_tag" PT
+WHERE
+    PT."product_id" = $1
+    AND PT."tag_id" = T."id"
+`
+
+type GetProductTagsRow struct {
+	ID   int32  `json:"id"`
+	Name string `json:"name"`
+}
+
+func (q *Queries) GetProductTags(ctx context.Context, productID int32) ([]GetProductTagsRow, error) {
+	rows, err := q.db.Query(ctx, getProductTags, productID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetProductTagsRow{}
+	for rows.Next() {
+		var i GetProductTagsRow
+		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getProductsFromNearByShop = `-- name: GetProductsFromNearByShop :many
 WITH nearby_shop AS (
     SELECT

--- a/db/queries/general.sql
+++ b/db/queries/general.sql
@@ -38,6 +38,24 @@ ORDER BY
     "id" ASC
 LIMIT $2 OFFSET $3;
 
+-- name: GetShopCouponDetails :one
+SELECT
+    "id",
+    "type",
+    "scope",
+    "name",
+    "description",
+    "discount",
+    "start_date",
+    "expire_date"
+FROM
+    "coupon"
+WHERE
+    "id" = $1
+    AND (
+        "shop_id" = $2
+        OR "scope" = 'global');
+
 -- name: GetTagInfo :one
 SELECT
     "id",
@@ -77,6 +95,18 @@ FROM
 WHERE
     PT."product_id" = $1
     AND PT."tag_id" = T."id";
+
+
+-- name: GetCouponTags :many
+SELECT
+    T."id",
+    T."name"
+FROM
+    "tag" T,
+    "coupon_tag" CT
+WHERE
+    CT."coupon_id" = $1
+    AND CT."tag_id" = T."id";
 
 -- name: GetShopProducts :many
 SELECT

--- a/db/queries/general.sql
+++ b/db/queries/general.sql
@@ -67,6 +67,17 @@ WHERE
     P."id" = $1
     AND P."enabled" = TRUE;
 
+-- name: GetProductTags :many
+SELECT
+    T."id",
+    T."name"
+FROM
+    "tag" T,
+    "product_tag" PT
+WHERE
+    PT."product_id" = $1
+    AND PT."tag_id" = T."id";
+
 -- name: GetShopProducts :many
 SELECT
     P."id",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2751,6 +2751,64 @@ const docTemplate = `{
                 }
             }
         },
+        "/shop/{seller_name}/coupon/{id}": {
+            "get": {
+                "description": "Get coupon detail for a shop with seller username and coupon id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Shop",
+                    "Coupon"
+                ],
+                "summary": "Get Shop coupon detail",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "seller username",
+                        "name": "seller_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "coupon id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/general.couponInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/shop/{seller_name}/search": {
             "get": {
                 "description": "Search products within a shop by seller username",
@@ -3529,6 +3587,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "shop_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "db.GetCouponTagsRow": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
                     "type": "string"
                 }
             }
@@ -4581,6 +4650,41 @@ const docTemplate = `{
                 },
                 "seller_name": {
                     "type": "string"
+                }
+            }
+        },
+        "general.couponInfo": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "discount": {
+                    "type": "number"
+                },
+                "expire_date": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
+                    "$ref": "#/definitions/db.CouponScope"
+                },
+                "start_date": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/db.GetCouponTagsRow"
+                    }
+                },
+                "type": {
+                    "$ref": "#/definitions/db.CouponType"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1195,7 +1195,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/db.GetProductInfoRow"
+                            "$ref": "#/definitions/general.productInfo"
                         }
                     },
                     "400": {
@@ -3701,41 +3701,14 @@ const docTemplate = `{
                 }
             }
         },
-        "db.GetProductInfoRow": {
+        "db.GetProductTagsRow": {
             "type": "object",
             "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "expire_date": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "integer"
                 },
                 "name": {
                     "type": "string"
-                },
-                "price": {
-                    "type": "number"
-                },
-                "product_image_url": {
-                    "type": "string"
-                },
-                "sales": {
-                    "type": "integer"
-                },
-                "seller_name": {
-                    "type": "string"
-                },
-                "shop_image_url": {
-                    "type": "string"
-                },
-                "shop_name": {
-                    "type": "string"
-                },
-                "stock": {
-                    "type": "integer"
                 }
             }
         },
@@ -4624,6 +4597,50 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/db.GetProductsFromPopularShopRow"
+                    }
+                }
+            }
+        },
+        "general.productInfo": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "expire_date": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "product_image_url": {
+                    "type": "string"
+                },
+                "sales": {
+                    "type": "integer"
+                },
+                "seller_name": {
+                    "type": "string"
+                },
+                "shop_image_url": {
+                    "type": "string"
+                },
+                "shop_name": {
+                    "type": "string"
+                },
+                "stock": {
+                    "type": "integer"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/db.GetProductTagsRow"
                     }
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1189,7 +1189,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/db.GetProductInfoRow"
+                            "$ref": "#/definitions/general.productInfo"
                         }
                     },
                     "400": {
@@ -3695,41 +3695,14 @@
                 }
             }
         },
-        "db.GetProductInfoRow": {
+        "db.GetProductTagsRow": {
             "type": "object",
             "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "expire_date": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "integer"
                 },
                 "name": {
                     "type": "string"
-                },
-                "price": {
-                    "type": "number"
-                },
-                "product_image_url": {
-                    "type": "string"
-                },
-                "sales": {
-                    "type": "integer"
-                },
-                "seller_name": {
-                    "type": "string"
-                },
-                "shop_image_url": {
-                    "type": "string"
-                },
-                "shop_name": {
-                    "type": "string"
-                },
-                "stock": {
-                    "type": "integer"
                 }
             }
         },
@@ -4618,6 +4591,50 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/db.GetProductsFromPopularShopRow"
+                    }
+                }
+            }
+        },
+        "general.productInfo": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "expire_date": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "product_image_url": {
+                    "type": "string"
+                },
+                "sales": {
+                    "type": "integer"
+                },
+                "seller_name": {
+                    "type": "string"
+                },
+                "shop_image_url": {
+                    "type": "string"
+                },
+                "shop_name": {
+                    "type": "string"
+                },
+                "stock": {
+                    "type": "integer"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/db.GetProductTagsRow"
                     }
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2745,6 +2745,64 @@
                 }
             }
         },
+        "/shop/{seller_name}/coupon/{id}": {
+            "get": {
+                "description": "Get coupon detail for a shop with seller username and coupon id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Shop",
+                    "Coupon"
+                ],
+                "summary": "Get Shop coupon detail",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "seller username",
+                        "name": "seller_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "coupon id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/general.couponInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/shop/{seller_name}/search": {
             "get": {
                 "description": "Search products within a shop by seller username",
@@ -3523,6 +3581,17 @@
                     "type": "string"
                 },
                 "shop_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "db.GetCouponTagsRow": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
                     "type": "string"
                 }
             }
@@ -4575,6 +4644,41 @@
                 },
                 "seller_name": {
                     "type": "string"
+                }
+            }
+        },
+        "general.couponInfo": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "discount": {
+                    "type": "number"
+                },
+                "expire_date": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
+                    "$ref": "#/definitions/db.CouponScope"
+                },
+                "start_date": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/db.GetCouponTagsRow"
+                    }
+                },
+                "type": {
+                    "$ref": "#/definitions/db.CouponType"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -229,6 +229,13 @@ definitions:
       shop_name:
         type: string
     type: object
+  db.GetCouponTagsRow:
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+    type: object
   db.GetGlobalCouponDetailRow:
     properties:
       description:
@@ -917,6 +924,29 @@ definitions:
         type: string
       seller_name:
         type: string
+    type: object
+  general.couponInfo:
+    properties:
+      description:
+        type: string
+      discount:
+        type: number
+      expire_date:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+      scope:
+        $ref: '#/definitions/db.CouponScope'
+      start_date:
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/db.GetCouponTagsRow'
+        type: array
+      type:
+        $ref: '#/definitions/db.CouponType'
     type: object
   general.popular:
     properties:
@@ -2954,6 +2984,45 @@ paths:
           schema:
             $ref: '#/definitions/echo.HTTPError'
       summary: Get Shop Coupons
+      tags:
+      - Shop
+      - Coupon
+  /shop/{seller_name}/coupon/{id}:
+    get:
+      consumes:
+      - application/json
+      description: Get coupon detail for a shop with seller username and coupon id
+      parameters:
+      - description: seller username
+        in: path
+        name: seller_name
+        required: true
+        type: string
+      - description: coupon id
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/general.couponInfo'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+      summary: Get Shop coupon detail
       tags:
       - Shop
       - Coupon

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -339,30 +339,12 @@ definitions:
       stock:
         type: integer
     type: object
-  db.GetProductInfoRow:
+  db.GetProductTagsRow:
     properties:
-      description:
-        type: string
-      expire_date:
-        type: string
       id:
         type: integer
       name:
         type: string
-      price:
-        type: number
-      product_image_url:
-        type: string
-      sales:
-        type: integer
-      seller_name:
-        type: string
-      shop_image_url:
-        type: string
-      shop_name:
-        type: string
-      stock:
-        type: integer
     type: object
   db.GetProductsFromNearByShopRow:
     properties:
@@ -945,6 +927,35 @@ definitions:
       popular_products:
         items:
           $ref: '#/definitions/db.GetProductsFromPopularShopRow'
+        type: array
+    type: object
+  general.productInfo:
+    properties:
+      description:
+        type: string
+      expire_date:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+      price:
+        type: number
+      product_image_url:
+        type: string
+      sales:
+        type: integer
+      seller_name:
+        type: string
+      shop_image_url:
+        type: string
+      shop_name:
+        type: string
+      stock:
+        type: integer
+      tags:
+        items:
+          $ref: '#/definitions/db.GetProductTagsRow'
         type: array
     type: object
   general.shopInfo:
@@ -1879,7 +1890,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/db.GetProductInfoRow'
+            $ref: '#/definitions/general.productInfo'
         "400":
           description: Bad Request
           schema:

--- a/pkg/router/general/common.go
+++ b/pkg/router/general/common.go
@@ -129,13 +129,18 @@ func GetPopular(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.Handler
 	}
 }
 
+type productInfo struct {
+	db.GetProductInfoRow
+	Tags []db.GetProductTagsRow `json:"tags"`
+}
+
 // @Summary		Get Product Info
 // @Description	Get product information with product ID
 // @Tags			Product
 // @Accept			json
 // @Produce		json
 // @Param			id	path		int	true	"Product ID"
-// @Success		200	{object}	db.GetProductInfoRow
+// @Success		200	{object}	productInfo
 // @Failure		400	{object}	echo.HTTPError
 // @Failure		404	{object}	echo.HTTPError
 // @Failure		500	{object}	echo.HTTPError
@@ -147,7 +152,9 @@ func GetProductInfo(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.Han
 			logger.Errorw("failed to parse id", "error", err)
 			return echo.NewHTTPError(http.StatusBadRequest)
 		}
-		result, err := pg.Queries.GetProductInfo(c.Request().Context(), id)
+		var err error
+		var result productInfo
+		result.GetProductInfoRow, err = pg.Queries.GetProductInfo(c.Request().Context(), id)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return echo.NewHTTPError(http.StatusNotFound, "Product Not Found")
@@ -155,8 +162,14 @@ func GetProductInfo(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.Han
 			logger.Errorw("failed to get product info", "error", err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
+		result.Tags, err = pg.Queries.GetProductTags(c.Request().Context(), id)
+		if err != nil {
+			logger.Errorw("failed to get product tags", "error", err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
 		result.ProductImageUrl = image.GetUrl(result.ProductImageUrl)
 		result.ShopImageUrl = image.GetUrl(result.ShopImageUrl)
+
 		return c.JSON(http.StatusOK, result)
 	}
 }

--- a/pkg/router/general/shop.go
+++ b/pkg/router/general/shop.go
@@ -122,3 +122,60 @@ func GetShopCoupon(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
 		return c.JSON(http.StatusOK, coupons)
 	}
 }
+
+type couponInfo struct {
+	db.GetShopCouponDetailsRow
+	Tags []db.GetCouponTagsRow `json:"tags"`
+}
+
+// @Summary		Get Shop coupon detail
+// @Description	Get coupon detail for a shop with seller username and coupon id
+// @Tags			Shop,Coupon
+// @Accept			json
+// @Produce		json
+// @Param			seller_name	path		string	true	"seller username"
+// @Param			id	path		int		true	"coupon id"
+// @Success		200			{object}	couponInfo
+// @Failure		400			{object}	echo.HTTPError
+// @Failure		404			{object}	echo.HTTPError
+// @Failure		500			{object}	echo.HTTPError
+// @Router			/shop/{seller_name}/coupon/{id} [get]
+func GetShopCouponDetail(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var param db.GetShopCouponDetailsParams
+		var err error
+		seller_name := c.Param("seller_name")
+		if seller_name == "" {
+			logger.Errorw("seller_name is empty")
+			return echo.NewHTTPError(http.StatusBadRequest)
+		}
+		shop_id, err := pg.Queries.ShopExists(c.Request().Context(), seller_name)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return echo.NewHTTPError(http.StatusNotFound, "Shop Not Found")
+			}
+			logger.Errorw("failed to check shop exists", "error", err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+		if err := echo.PathParamsBinder(c).Int32("id", &param.ID).BindError(); err != nil {
+			logger.Errorw("failed to parse id", "error", err)
+			return echo.NewHTTPError(http.StatusBadRequest)
+		}
+		param.ShopID.Int32 = shop_id
+		param.ShopID.Valid = true
+		var result couponInfo
+		result.GetShopCouponDetailsRow, err = pg.Queries.GetShopCouponDetails(c.Request().Context(), param)
+		if err != nil {
+			logger.Errorw("failed to get shop coupons", "error", err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+		if result.Scope != "global" {
+			result.Tags, err = pg.Queries.GetCouponTags(c.Request().Context(), param.ID)
+			if err != nil {
+				logger.Errorw("failed to get coupon tags", "error", err)
+				return echo.NewHTTPError(http.StatusInternalServerError)
+			}
+		}
+		return c.JSON(http.StatusOK, result)
+	}
+}

--- a/pkg/router/general/shop.go
+++ b/pkg/router/general/shop.go
@@ -169,6 +169,7 @@ func GetShopCouponDetail(pg *db.DB, logger *zap.SugaredLogger) echo.HandlerFunc 
 			logger.Errorw("failed to get shop coupons", "error", err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
+		result.Tags = []db.GetCouponTagsRow{}
 		if result.Scope != "global" {
 			result.Tags, err = pg.Queries.GetCouponTags(c.Request().Context(), param.ID)
 			if err != nil {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -66,6 +66,7 @@ func RegisterApi(e *echo.Echo, pg *db.DB, mc *minio.MC, logger *zap.SugaredLogge
 	// general
 	api.GET("/shop/:seller_name", general.GetShopInfo(pg, mc, logger)) // user
 	api.GET("/shop/:seller_name/coupon", general.GetShopCoupon(pg, logger))
+	api.GET("/shop/:seller_name/coupon/:id", general.GetShopCouponDetail(pg, logger))
 	api.GET("/shop/:seller_name/search", general.SearchShopProduct(pg, mc, logger))
 
 	api.GET("/tag/:id", general.GetTagInfo(pg, logger))

--- a/pkg/router/seller/shop.go
+++ b/pkg/router/seller/shop.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jykuo-love-shiritori/twp/db"
 	"github.com/jykuo-love-shiritori/twp/minio"
@@ -36,6 +37,11 @@ func GetShopInfo(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.Handle
 		}
 		shopInfo, err := pg.Queries.SellerGetInfo(c.Request().Context(), username)
 		if err != nil {
+			_, ok := err.(pgx.ScanArgError)
+			if ok {
+				return c.JSON(http.StatusOK, []db.SellerGetInfoRow{})
+			}
+
 			logger.Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}


### PR DESCRIPTION
<!-- Description or Related Issues -->
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Resolves #139 Resolves #142
the current response for  `/api/product/:id` is 
```json
{
  "description": "string",
  "expire_date": "string",
  "id": 0,
  "name": "string",
  "price": 0,
  "product_image_url": "string",
  "sales": 0,
  "seller_name": "string",
  "shop_image_url": "string",
  "shop_name": "string",
  "stock": 0,
  "tags": [
    {
      "id": 0,
      "name": "string"
    }
  ]
}
```
the current response for `/api/shop/{seller_name}/coupon/{id}` like under
```json
{
  "description": "string",
  "discount": 0,
  "expire_date": "string",
  "id": 0,
  "name": "string",
  "scope": "global",
  "start_date": "string",
  "tags": [
    {
      "id": 0,
      "name": "string"
    }
  ],
  "type": "percentage"
}
```
### Changes
- Add `tags` for `/api/product/:id`
- Create `/api/shop/{seller_name}/coupon/{id}` endpoint
- Add additional error check at `pkg/router/seller/shop.go` `GetShopInfo`
### Testing Approach (if unconventional)
<!-- Describe how you tested your changes, including details of your testing environment and the tests you ran to evaluate the impact on other code areas. -->

Call `/api/product/:id` with any exist and enable product's id
It should include corresponding product's  `tags` in response.
Create any coupon for shop and call `/api/shop/{seller_name}/coupon/{id}` with its `id` and `seller_name`
Also, you may use admin to create a global coupon, and call the same API, and the `"tags"` in response would be `[]`
