### PR TITLE
[frontend] control enabled, more items, get username

### DIFF
--- a/frontend/src/components/FormItem.tsx
+++ b/frontend/src/components/FormItem.tsx
@@ -3,19 +3,20 @@ import { Row, Col } from 'react-bootstrap';
 interface Props {
   label: string;
   children: JSX.Element;
+  isCenter?: boolean;
 }
 
 const FormItemStyle = {
   margin: '3% 0% 3% 0%',
 };
 
-const FormItem = ({ label, children }: Props) => {
+const FormItem = ({ label, children, isCenter = true }: Props) => {
   return (
     <Row style={FormItemStyle}>
       <Col xs={12} md={4} className='center_vertical'>
         {label}
       </Col>
-      <Col xs={12} md={8} className='form_item_wrapper'>
+      <Col xs={12} md={8} className={!isCenter ? '' : 'form_item_wrapper'}>
         {children}
       </Col>
     </Row>

--- a/frontend/src/pages/discover/index.tsx
+++ b/frontend/src/pages/discover/index.tsx
@@ -15,7 +15,7 @@ const Discover = () => {
   const { status, data: goodsData } = useQuery({
     queryKey: ['discover'],
     queryFn: async () => {
-      const response = await fetch(`/api/discover?offset=${0}&limit=${12}`, {
+      const response = await fetch(`/api/discover?offset=${0}&limit=${20}`, {
         headers: {
           Accept: 'application/json',
         },

--- a/frontend/src/pages/user/buyer/history/index.tsx
+++ b/frontend/src/pages/user/buyer/history/index.tsx
@@ -14,7 +14,7 @@ const History = () => {
   const { status, data: buyerOrderData } = useQuery({
     queryKey: ['buyerOder'],
     queryFn: async () => {
-      const response = await fetch(`/api/buyer/order?offset=0&limit=8`, {
+      const response = await fetch(`/api/buyer/order?offset=0&limit=20`, {
         headers: {
           Accept: 'application/json',
           Authorization: `Bearer ${token}`,

--- a/frontend/src/pages/user/seller/allProducts/NewGoods.tsx
+++ b/frontend/src/pages/user/seller/allProducts/NewGoods.tsx
@@ -11,7 +11,7 @@ import React, { useReducer, CSSProperties } from 'react';
 
 import TButton from '@components/TButton';
 import FormItem from '@components/FormItem';
-import { useAuth } from '@lib/Auth';
+import { useAuth, GetUserName } from '@lib/Auth';
 
 export const GoodsImgStyle: CSSProperties = {
   borderRadius: '0 0 30px 0',
@@ -41,7 +41,7 @@ export interface ProductProps {
   image: File | string;
   expire_date: string;
   stock: number;
-  enable: boolean;
+  enabled: boolean;
   tags: number[];
 }
 
@@ -114,7 +114,7 @@ export const SetFormData = (data: ProductProps) => {
   formData.append('price', String(data.price));
   formData.append('expire_date', new Date(data.expire_date).toISOString());
   formData.append('stock', String(data.stock));
-  formData.append('enable', String(data.enable));
+  formData.append('enabled', String(data.enabled));
   formData.append('tags', data.tags.join(','));
   return formData;
 };
@@ -163,6 +163,7 @@ const deleteTagsAction = (index: number): DeleteTagsAction => {
 const EmptyGoods = () => {
   const token = useAuth();
   const navigate = useNavigate();
+  const username = GetUserName();
 
   const [tag, setTag] = useState('');
   const [reducerTags, dispatchTags] = useReducer(tagsReducer, []);
@@ -177,7 +178,7 @@ const EmptyGoods = () => {
       image: undefined,
       expire_date: 'expire date',
       stock: 0,
-      enable: true,
+      enabled: true,
       tags: undefined,
     },
   });
@@ -277,8 +278,10 @@ const EmptyGoods = () => {
             dispatchTags({ type: ADD_TAG, payload: existingTag });
             updateTags();
           } else {
-            // TODO : seller name need to be change to corresponding user
-            addTag.mutate({ name: tag, seller_name: 'user1' });
+            if (username === undefined) {
+              return;
+            }
+            addTag.mutate({ name: tag, seller_name: username });
           }
           Reset();
         },
@@ -459,6 +462,10 @@ const EmptyGoods = () => {
                   type='date'
                   {...register('expire_date', { required: true, validate: { date: () => true } })}
                 />
+              </FormItem>
+
+              <FormItem label='Product Listing' isCenter={false}>
+                <input type='checkbox' {...register('enabled')} />
               </FormItem>
             </div>
           </Col>

--- a/frontend/src/pages/user/seller/allProducts/[sellerGoodsID].tsx
+++ b/frontend/src/pages/user/seller/allProducts/[sellerGoodsID].tsx
@@ -11,7 +11,7 @@ import React, { useReducer } from 'react';
 
 import TButton from '@components/TButton';
 import FormItem from '@components/FormItem';
-import { useAuth } from '@lib/Auth';
+import { GetUserName, useAuth } from '@lib/Auth';
 
 import {
   TagProps,
@@ -34,7 +34,7 @@ export interface TagPropsAnotherVersion {
 export interface GetResponseProps {
   product_info: {
     description: string;
-    enable: boolean;
+    enabled: boolean;
     expire_date: string;
     id: number;
     image_url: string;
@@ -56,7 +56,7 @@ interface PatchResponseProps {
   edit_date: string;
   stock: number;
   sales: number;
-  enable: boolean;
+  enabled: boolean;
 }
 
 interface ConnectionTagsPros {
@@ -91,6 +91,7 @@ const deleteTagsAction = (index: number): DeleteTagsAction => {
 const EachSellerGoods = () => {
   const token = useAuth();
   const navigate = useNavigate();
+  const username = GetUserName();
 
   const params = useParams<{ goods_id?: string }>();
   let goods_id: number | undefined;
@@ -112,7 +113,7 @@ const EachSellerGoods = () => {
       image: undefined,
       expire_date: 'expire date',
       stock: 0,
-      enable: true,
+      enabled: true,
       tags: [],
     },
   });
@@ -184,7 +185,7 @@ const EachSellerGoods = () => {
         new Date(responseData.product_info.expire_date).toLocaleDateString('en-CA'),
       );
       setValue('stock', responseData.product_info.stock);
-      setValue('enable', Boolean(responseData.product_info.enable));
+      setValue('enabled', Boolean(responseData.product_info.enabled));
       const convertedTags = responseData.tags.map((tag) => ({
         id: tag.tag_id,
         name: tag.name,
@@ -229,7 +230,7 @@ const EachSellerGoods = () => {
       setValue('image', responseData.image_url);
       setValue('expire_date', new Date(responseData.expire_date).toLocaleDateString('en-CA'));
       setValue('stock', responseData.stock);
-      setValue('enable', Boolean(responseData.enable));
+      setValue('enabled', Boolean(responseData.enabled));
       navigate('/user/seller/manageProducts');
     },
   });
@@ -323,8 +324,10 @@ const EachSellerGoods = () => {
             updateTags();
             await connectTag.mutate({ id: goods_id, tag_id: existingTag.id });
           } else {
-            // TODO : seller name need to be change to corresponding user
-            addTag.mutate({ name: tag, seller_name: 'user1' });
+            if (username === undefined) {
+              return;
+            }
+            addTag.mutate({ name: tag, seller_name: username });
           }
 
           Reset();
@@ -511,6 +514,10 @@ const EachSellerGoods = () => {
 
               <FormItem label='Best Before Date'>
                 <input type='date' {...register('expire_date', { required: true })} />
+              </FormItem>
+
+              <FormItem label='Product Listing' isCenter={false}>
+                <input type='checkbox' {...register('enabled')} />
               </FormItem>
             </div>
           </Col>

--- a/frontend/src/pages/user/seller/allProducts/index.tsx
+++ b/frontend/src/pages/user/seller/allProducts/index.tsx
@@ -15,7 +15,7 @@ const Products = () => {
   const { status, data: sellerShopData } = useQuery({
     queryKey: ['sellerShopView'],
     queryFn: async () => {
-      const response = await fetch(`/api/seller/product?offset=${0}&limit=${8}`, {
+      const response = await fetch(`/api/seller/product?offset=${0}&limit=${20}`, {
         headers: {
           Accept: 'application/json',
           Authorization: `Bearer ${token}`,

--- a/frontend/src/pages/user/seller/allShipments/index.tsx
+++ b/frontend/src/pages/user/seller/allShipments/index.tsx
@@ -14,7 +14,7 @@ const SellerShipment = () => {
   const { status, data: sellerOrderData } = useQuery({
     queryKey: ['sellerOder'],
     queryFn: async () => {
-      const response = await fetch(`/api/seller/order?offset=0&limit=8`, {
+      const response = await fetch(`/api/seller/order?offset=0&limit=20`, {
         headers: {
           Accept: 'application/json',
           Authorization: `Bearer ${token}`,

--- a/frontend/src/pages/user/shop/Shop.tsx
+++ b/frontend/src/pages/user/shop/Shop.tsx
@@ -14,7 +14,7 @@ const Shop = () => {
   const { status, data: shopData } = useQuery({
     queryKey: ['shopsView'],
     queryFn: async () => {
-      const response = await fetch(`/api/seller/product?offset=${0}&limit=${8}`, {
+      const response = await fetch(`/api/seller/product?offset=${0}&limit=${20}`, {
         headers: {
           Accept: 'application/json',
           Authorization: `Bearer ${token}`,


### PR DESCRIPTION
<!-- Description or Related Issues -->
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Resolveeeeeeeees part of #94

### Changes
<!-- List the changes introduced by this pull request. -->

- add more item in manageProducts, UserViewShop, discover, buyer&seller history page
- add tag to corresponding user rather than putting `user1`
- seller can control if product is visible or not
  - <img width="1680" alt="image" src="https://github.com/jykuo-love-shiritori/twp/assets/92158595/2cbb844d-aa84-4b60-80b2-5f8c67177f2e">
  - <img width="1680" alt="image" src="https://github.com/jykuo-love-shiritori/twp/assets/92158595/912ea48a-c64f-4e16-830f-bbecc5ffa57d">


### Test Environment Setup
open 3 terminals
one for `docker-compose up postgres minio `
one for `go run .`
one for `cd frontend` -> `npm i` -> `npm run build`
then open the browser then enter http://localhost:8080/ 

### Additional context
<!-- Add any other context or screenshots about the pull request here. -->
N/A