### PR TITLE
[backend] Fix #167 #171

### DIFF
--- a/db/admin.sql.go
+++ b/db/admin.sql.go
@@ -395,7 +395,6 @@ SELECT S."seller_name",
 FROM "shop" AS S,
     "order_history" AS O
 WHERE S."id" = O."shop_id"
-    AND O."status" = 'paid'
     AND O."created_at" BETWEEN $1 AND $1 + INTERVAL '1 month'
 GROUP BY S."seller_name",
     S."name",

--- a/db/migrations/000005_coupon_constraint.down.sql
+++ b/db/migrations/000005_coupon_constraint.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "coupon" DROP CONSTRAINT "shop_coupon_constraint";

--- a/db/migrations/000005_coupon_constraint.up.sql
+++ b/db/migrations/000005_coupon_constraint.up.sql
@@ -1,0 +1,5 @@
+DELETE FROM "coupon" WHERE "shop_id" IS NULL AND "scope" = 'shop';
+ALTER TABLE "coupon"
+    ADD CONSTRAINT "shop_coupon_constraint" CHECK (
+        NOT ("shop_id" IS NULL AND "scope" = 'shop')
+    );

--- a/db/queries/admin.sql
+++ b/db/queries/admin.sql
@@ -125,7 +125,6 @@ SELECT S."seller_name",
 FROM "shop" AS S,
     "order_history" AS O
 WHERE S."id" = O."shop_id"
-    AND O."status" = 'paid'
     AND O."created_at" BETWEEN sqlc.arg('date') AND sqlc.arg('date') + INTERVAL '1 month'
 GROUP BY S."seller_name",
     S."name",

--- a/db/test.sql.go
+++ b/db/test.sql.go
@@ -520,8 +520,8 @@ VALUES (
         $5,
         $6,
         $7,
-        NOW(),
         $8,
+        NOW(),
         $9,
         $10,
         $11
@@ -537,7 +537,7 @@ type TestInsertProductParams struct {
 	Description string             `form:"description" json:"description"`
 	Price       pgtype.Numeric     `json:"price" swaggertype:"number"`
 	ImageID     string             `json:"image_id"`
-	EditDate    pgtype.Timestamptz `json:"edit_date" swaggertype:"string"`
+	ExpireDate  pgtype.Timestamptz `json:"expire_date" swaggertype:"string"`
 	Stock       int32              `form:"stock" json:"stock"`
 	Sales       int32              `json:"sales"`
 	Enabled     bool               `form:"enabled" json:"enabled"`
@@ -552,7 +552,7 @@ func (q *Queries) TestInsertProduct(ctx context.Context, arg TestInsertProductPa
 		arg.Description,
 		arg.Price,
 		arg.ImageID,
-		arg.EditDate,
+		arg.ExpireDate,
 		arg.Stock,
 		arg.Sales,
 		arg.Enabled,

--- a/pkg/router/seller/shop.go
+++ b/pkg/router/seller/shop.go
@@ -120,9 +120,11 @@ func EditInfo(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.HandlerFu
 			logger.Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
-		if err := pg.Queries.WithTx(tx).DisableShop(c.Request().Context(), username); err != nil {
-			logger.Error(err)
-			return echo.NewHTTPError(http.StatusInternalServerError)
+		if param.Enabled == false {
+			if err := pg.Queries.WithTx(tx).DisableShop(c.Request().Context(), username); err != nil {
+				logger.Error(err)
+				return echo.NewHTTPError(http.StatusInternalServerError)
+			}
 		}
 		if err := tx.Commit(c.Request().Context()); err != nil {
 			logger.Error(err)

--- a/pkg/router/seller/shop.go
+++ b/pkg/router/seller/shop.go
@@ -120,7 +120,7 @@ func EditInfo(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.HandlerFu
 			logger.Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
-		if param.Enabled == false {
+		if !param.Enabled {
 			if err := pg.Queries.WithTx(tx).DisableShop(c.Request().Context(), username); err != nil {
 				logger.Error(err)
 				return echo.NewHTTPError(http.StatusInternalServerError)

--- a/pkg/router/seller/shop.go
+++ b/pkg/router/seller/shop.go
@@ -101,8 +101,14 @@ func EditInfo(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.HandlerFu
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}
 
+		tx, err := pg.NewTx(c.Request().Context())
+		if err != nil {
+			logger.Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+		defer tx.Rollback(c.Request().Context()) //nolint:errcheck
 		param.SellerName = username
-		shopInfo, err := pg.Queries.SellerUpdateInfo(c.Request().Context(), param)
+		shopInfo, err := pg.Queries.WithTx(tx).SellerUpdateInfo(c.Request().Context(), param)
 		if err != nil {
 			if param.ImageID != "" {
 				err := mc.RemoveFile(c.Request().Context(), param.ImageID)
@@ -111,6 +117,14 @@ func EditInfo(pg *db.DB, mc *minio.MC, logger *zap.SugaredLogger) echo.HandlerFu
 					return echo.NewHTTPError(http.StatusInternalServerError)
 				}
 			}
+			logger.Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+		if err := pg.Queries.WithTx(tx).DisableShop(c.Request().Context(), username); err != nil {
+			logger.Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError)
+		}
+		if err := tx.Commit(c.Request().Context()); err != nil {
 			logger.Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError)
 		}


### PR DESCRIPTION
<!-- Description or Related Issues -->
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Trickly Resolves #167 
Fix #169 Fix #171
### Changes
- Add constraint for table, so adding coupon when the shop would cause 500 Internal server error
- Use transaction to disable shop's product when the set shop `enabled == false`
- Remove `O."status" in admin's report query`
### Testing Approach (if unconventional)
Disable a user's shop, creating a coupon will cause Internal Server Error
Disable a user's shop, its all products should be disabled.
Buy something and process the order status to any status. Admin report would consider the order success.